### PR TITLE
Better add remove entity

### DIFF
--- a/components/component.h
+++ b/components/component.h
@@ -11,25 +11,15 @@
 
 namespace godex {
 
-#define COMPONENT_INTERNAL(m_class)                                                                   \
-	/* Components */                                                                                  \
-	static inline uint32_t component_id = UINT32_MAX;                                                 \
-																									  \
-	static void add_component_by_name(World *p_world, EntityID entity_id, const Dictionary &p_data) { \
-		m_class component;                                                                            \
-		for (const Variant *key = p_data.next(nullptr); key != nullptr; key = p_data.next(key)) {     \
-			component.set(StringName(*key), p_data.get_valid(*key));                                  \
-		}                                                                                             \
-		p_world->add_component(                                                                       \
-				entity_id,                                                                            \
-				component);                                                                           \
-	}                                                                                                 \
-																									  \
-public:                                                                                               \
-	static uint32_t get_component_id() { return component_id; }                                       \
-	virtual godex::component_id cid() const override { return component_id; }                         \
-																									  \
-	ECS_PROPERTY_MAPPER(m_class)                                                                      \
+#define COMPONENT_INTERNAL(m_class)                                           \
+	/* Components */                                                          \
+	static inline uint32_t component_id = UINT32_MAX;                         \
+																			  \
+public:                                                                       \
+	static uint32_t get_component_id() { return component_id; }               \
+	virtual godex::component_id cid() const override { return component_id; } \
+																			  \
+	ECS_PROPERTY_MAPPER(m_class)                                              \
 private:
 
 #define COMPONENT(m_class, m_storage_class)                            \

--- a/components/component.h
+++ b/components/component.h
@@ -27,9 +27,6 @@ private:
 	friend class World;                                                \
 	friend class Component;                                            \
 																	   \
-public:                                                                \
-	typedef bool_type<false> is_event;                                 \
-																	   \
 private:                                                               \
 	/* Storages */                                                     \
 	static _FORCE_INLINE_ m_storage_class<m_class> *create_storage() { \
@@ -45,9 +42,6 @@ private:                                                               \
 	ECSCLASS(m_class)                                                                         \
 	friend class World;                                                                       \
 	friend class Component;                                                                   \
-																							  \
-public:                                                                                       \
-	typedef bool_type<false> is_event;                                                        \
 																							  \
 private:                                                                                      \
 	/* Storages */                                                                            \

--- a/ecs.cpp
+++ b/ecs.cpp
@@ -293,6 +293,7 @@ void ECS::dispatch_active_world() {
 	if (likely(active_world && active_world_pipeline)) {
 		dispatching = true;
 		active_world_pipeline->dispatch(active_world);
+		active_world->flush();
 		dispatching = false;
 	}
 }

--- a/godot/nodes/ecs_world.h
+++ b/godot/nodes/ecs_world.h
@@ -134,6 +134,7 @@ private:
 	void unactive_world();
 };
 
+// TODO remove this and handle directly via storages and WorldCommands.
 /// World Manipulatort
 class WorldECSCommands : public Object {
 	GDCLASS(WorldECSCommands, Object)

--- a/iterators/dynamic_query.cpp
+++ b/iterators/dynamic_query.cpp
@@ -172,7 +172,7 @@ EntityID DynamicQuery::get_current_entity_id() const {
 // TODO see how to improve this lookup mechanism so that no cache is miss and
 // it's fast.
 void DynamicQuery::next() {
-	const uint32_t last_id = world->get_last_entity_id();
+	const uint32_t last_id = world->get_biggest_entity_id();
 	if (unlikely(entity_id == UINT32_MAX || last_id == UINT32_MAX)) {
 		entity_id = UINT32_MAX;
 		return;

--- a/iterators/query.h
+++ b/iterators/query.h
@@ -186,7 +186,7 @@ public:
 	}
 
 	void next() {
-		const uint32_t last_id = world->get_last_entity_id();
+		const uint32_t last_id = world->get_biggest_entity_id();
 		if (unlikely(id == UINT32_MAX || last_id == UINT32_MAX)) {
 			id = UINT32_MAX;
 			return;

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -64,6 +64,7 @@ void register_godex_types() {
 	ECS::register_component<TransformComponent>();
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Register engine databags
+	ECS::register_databag<WorldCommands>();
 	ECS::register_databag<World>();
 
 	// Engine

--- a/tests/test_ecs_world.h
+++ b/tests/test_ecs_world.h
@@ -20,9 +20,11 @@ namespace godex_tests_world {
 
 TEST_CASE("[Modules][ECS] Test world has self databag.") {
 	World world;
+	godex::Databag *commands_ptr = world.get_databag(WorldCommands::get_databag_id());
 	godex::Databag *world_ptr = world.get_databag(World::get_databag_id());
 
-	// Make sure `World` contains a pointer of itself as databag.
+	// Make sure `World` contains a pointer of its commands as `Databag`.
+	CHECK(&world.get_commands() == commands_ptr);
 	CHECK(&world == world_ptr);
 }
 


### PR DESCRIPTION
Fixes #30

Added the possibility to **add** and **remove** a `Component` from a `System` using the `WorldCommands`.

Differently from the `World`, `WorldCommands` is designed to create and remove `Entities` in multi threads.

**Example**
```cpp
void test_add_entity_system(WorldCommands *p_commands, Storage<TransformComponent> *p_events) {
	for (uint32_t i = 0; i < 3; i += 1) {
		const EntityID id = p_commands->create_entity_index();
		p_events->insert(id, TransformComponent());
	}
}

void test_remove_entity_system(WorldCommands *p_command, Query<const TransformComponent> &p_query) {
	while (p_query.is_done() == false) {
		p_command->destroy_deferred(p_query.get_current_entity());
		p_query.next();
	}
}
```