### PR TITLE
Exposing Databag and Components methods

### DIFF
--- a/components/component.cpp
+++ b/components/component.cpp
@@ -6,7 +6,7 @@ using godex::Component;
 
 Component::Component() {}
 
-void Component::_bind_properties() {}
+void Component::_bind_methods() {}
 
 godex::component_id Component::cid() const {
 	CRASH_NOW_MSG("The component class must always be tagged using the macro `COMPONENT()`.");
@@ -42,4 +42,8 @@ Variant Component::get(const StringName &p_name) const {
 	Variant r;
 	get(p_name, r);
 	return r;
+}
+
+void Component::call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) {
+	CRASH_NOW_MSG("The component class must always be tagged using the macro `COMPONENT()`.");
 }

--- a/components/component.h
+++ b/components/component.h
@@ -20,6 +20,7 @@ public:                                                                       \
 	virtual godex::component_id cid() const override { return component_id; } \
 																			  \
 	ECS_PROPERTY_MAPPER(m_class)                                              \
+	ECS_METHOD_MAPPER()                                                       \
 private:
 
 #define COMPONENT(m_class, m_storage_class)                            \
@@ -61,7 +62,7 @@ public:
 	Component();
 
 public:
-	static void _bind_properties();
+	static void _bind_methods();
 
 	/// Returns the component ID.
 	virtual component_id cid() const;
@@ -74,6 +75,8 @@ public:
 	virtual bool get(const uint32_t p_parameter_index, Variant &r_data) const;
 
 	Variant get(const StringName &p_name) const;
+
+	virtual void call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error);
 };
 
 template <class T>

--- a/components/component.h
+++ b/components/component.h
@@ -81,7 +81,7 @@ public:
 
 template <class T>
 T *unwrap_component(Object *p_access_databag) {
-	DataAccessorScriptInstance<Component> *comp = dynamic_cast<DataAccessorScriptInstance<Component> *>(p_access_databag);
+	DataAccessor<Component> *comp = dynamic_cast<DataAccessor<Component> *>(p_access_databag);
 	if (unlikely(comp == nullptr || comp->__target == nullptr)) {
 		return nullptr;
 	}
@@ -94,7 +94,7 @@ T *unwrap_component(Object *p_access_databag) {
 
 template <class T>
 const T *unwrap_component(const Object *p_access_databag) {
-	const DataAccessorScriptInstance<Component> *comp = dynamic_cast<const DataAccessorScriptInstance<Component> *>(p_access_databag);
+	const DataAccessor<Component> *comp = dynamic_cast<const DataAccessor<Component> *>(p_access_databag);
 	if (unlikely(comp == nullptr || comp->__target == nullptr)) {
 		return nullptr;
 	}

--- a/databags/databag.cpp
+++ b/databags/databag.cpp
@@ -4,7 +4,7 @@
 
 godex::Databag::Databag() {}
 
-void godex::Databag::_bind_properties() {}
+void godex::Databag::_bind_methods() {}
 
 godex::databag_id godex::Databag::rid() const {
 	CRASH_NOW_MSG("The `Databag` class must always be tagged using the macro `DATABAG()`.");
@@ -40,4 +40,8 @@ Variant godex::Databag::get(const StringName &p_name) const {
 	Variant r;
 	get(p_name, r);
 	return r;
+}
+
+void godex::Databag::call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) {
+	CRASH_NOW_MSG("The `Databag` class must always be tagged using the macro `DATABAG()`.");
 }

--- a/databags/databag.h
+++ b/databags/databag.h
@@ -31,6 +31,7 @@ public:                                                                   \
 	virtual godex::databag_id rid() const override { return databag_id; } \
 																		  \
 	ECS_PROPERTY_MAPPER(m_class)                                          \
+	ECS_METHOD_MAPPER()                                                   \
 private:
 
 class Databag : public ECSClass {
@@ -40,7 +41,7 @@ public:
 	Databag();
 
 public:
-	static void _bind_properties();
+	static void _bind_methods();
 
 	/// Returns the resouce ID.
 	virtual databag_id rid() const;
@@ -53,6 +54,8 @@ public:
 	virtual bool get(const uint32_t p_parameter_index, Variant &r_data) const;
 
 	Variant get(const StringName &p_name) const;
+
+	virtual void call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error);
 };
 
 template <class T>

--- a/databags/databag.h
+++ b/databags/databag.h
@@ -60,7 +60,7 @@ public:
 
 template <class T>
 T *unwrap_databag(Object *p_access_databag) {
-	DataAccessorScriptInstance<Databag> *bag = dynamic_cast<DataAccessorScriptInstance<Databag> *>(p_access_databag);
+	DataAccessor<Databag> *bag = dynamic_cast<DataAccessor<Databag> *>(p_access_databag);
 	if (unlikely(bag == nullptr || bag->__target == nullptr)) {
 		return nullptr;
 	}
@@ -73,7 +73,7 @@ T *unwrap_databag(Object *p_access_databag) {
 
 template <class T>
 const T *unwrap_databag(const Object *p_access_databag) {
-	const DataAccessorScriptInstance<Databag> *bag = dynamic_cast<const DataAccessorScriptInstance<Databag> *>(p_access_databag);
+	const DataAccessor<Databag> *bag = dynamic_cast<const DataAccessor<Databag> *>(p_access_databag);
 	if (unlikely(bag == nullptr || bag->__target == nullptr)) {
 		return nullptr;
 	}

--- a/ecs.h
+++ b/ecs.h
@@ -59,7 +59,7 @@ class ECS : public Object {
 	World *active_world = nullptr;
 	Pipeline *active_world_pipeline = nullptr;
 	bool dispatching = false;
-	DataAccessorScriptInstance<godex::Databag> world_access;
+	DataAccessor<godex::Databag> world_access;
 
 public:
 	// ~~ Components ~~

--- a/ecs.h
+++ b/ecs.h
@@ -197,7 +197,7 @@ void ECS::register_component() {
 
 	StringName component_name = C::get_class_static();
 	C::component_id = components.size();
-	C::_bind_properties();
+	C::_bind_methods();
 	components.push_back(component_name);
 	components_info.push_back(
 			ComponentInfo{
@@ -226,7 +226,7 @@ void ECS::register_databag() {
 
 	StringName databag_name = R::get_class_static();
 	R::databag_id = databags.size();
-	R::_bind_properties();
+	R::_bind_methods();
 	databags.push_back(databag_name);
 	databags_info.push_back(DatabagInfo{
 			R::create_databag_no_type });

--- a/ecs_types.h
+++ b/ecs_types.h
@@ -451,12 +451,9 @@ public:                                                                         
 		return singleton;                                                                             \
 	}
 
-// TODO please rename this and re-document it. It's no more correct now.
-/// This is useful to access the storages fast. Since `Object::set` check fist
-/// the script. However, in future would be really nice make `Object::set` virtual
-/// so to override it and avoid all this useless extra work.
+/// This is useful to access the Component / Databag / Storage.
 template <class E>
-class DataAccessorScriptInstance : public Object {
+class DataAccessor : public Object {
 public:
 	E *__target = nullptr;
 	bool __mut = false;

--- a/ecs_types.h
+++ b/ecs_types.h
@@ -151,6 +151,9 @@ public:
 	EntityID(uint32_t p_index) :
 			id(p_index) {}
 
+	EntityID(Variant p_index) :
+			id(p_index.operator unsigned int()) {}
+
 	bool is_null() const {
 		return id == UINT32_MAX;
 	}
@@ -165,6 +168,10 @@ public:
 
 	operator uint32_t() const {
 		return id;
+	}
+
+	operator Variant() const {
+		return Variant(id);
 	}
 };
 

--- a/ecs_types.h
+++ b/ecs_types.h
@@ -451,6 +451,7 @@ public:                                                                         
 		return singleton;                                                                             \
 	}
 
+// TODO please rename this and re-document it. It's no more correct now.
 /// This is useful to access the storages fast. Since `Object::set` check fist
 /// the script. However, in future would be really nice make `Object::set` virtual
 /// so to override it and avoid all this useless extra work.

--- a/godot/components/mesh_component.cpp
+++ b/godot/components/mesh_component.cpp
@@ -4,7 +4,7 @@
 
 MeshComponent::MeshComponent() {}
 
-void MeshComponent::_bind_properties() {
+void MeshComponent::_bind_methods() {
 	ECS_BIND_PROPERTY(MeshComponent, PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), mesh);
 	ECS_BIND_PROPERTY(MeshComponent, PropertyInfo(Variant::OBJECT, "material_override", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,StandardMaterial3D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_DEFERRED_SET_RESOURCE), material_override);
 	ECS_BIND_PROPERTY(MeshComponent, PropertyInfo(Variant::INT, "layers", PROPERTY_HINT_LAYERS_3D_RENDER, ""), layers);

--- a/godot/components/mesh_component.h
+++ b/godot/components/mesh_component.h
@@ -19,7 +19,7 @@ class MeshComponent : public godex::Component {
 public:
 	MeshComponent();
 
-	static void _bind_properties();
+	static void _bind_methods();
 
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh() const;

--- a/godot/components/transform_component.cpp
+++ b/godot/components/transform_component.cpp
@@ -29,6 +29,6 @@ bool TransformComponent::is_changed() const {
 	return changed;
 }
 
-void TransformComponent::_bind_properties() {
+void TransformComponent::_bind_methods() {
 	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform"), transform);
 }

--- a/godot/components/transform_component.h
+++ b/godot/components/transform_component.h
@@ -27,7 +27,7 @@ public:
 	bool is_changed() const;
 
 protected:
-	static void _bind_properties();
+	static void _bind_methods();
 };
 
 #endif

--- a/godot/databags/godot_engine_databags.cpp
+++ b/godot/databags/godot_engine_databags.cpp
@@ -4,7 +4,7 @@
 #include "core/object/message_queue.h"
 #include "core/os/os.h"
 
-void FrameTime::_bind_properties() {
+void FrameTime::_bind_methods() {
 	ECS_BIND_PROPERTY(FrameTime, PropertyInfo(Variant::FLOAT, "delta"), delta);
 	ECS_BIND_PROPERTY(FrameTime, PropertyInfo(Variant::FLOAT, "physics_delta"), physics_delta);
 }
@@ -44,7 +44,7 @@ real_t FrameTime::get_physics_delta() const {
 	return physics_delta;
 }
 
-void OsDatabag::_bind_properties() {}
+void OsDatabag::_bind_methods() {}
 
 OsDatabag::OsDatabag() {
 	os_singleton = OS::get_singleton();
@@ -58,7 +58,7 @@ const OS *OsDatabag::get_os() const {
 	return os_singleton;
 }
 
-void EngineDatabag::_bind_properties() {}
+void EngineDatabag::_bind_methods() {}
 
 EngineDatabag::EngineDatabag() {
 	engine_singleton = Engine::get_singleton();
@@ -72,7 +72,7 @@ const Engine *EngineDatabag::get_engine() const {
 	return engine_singleton;
 }
 
-void MessageQueueDatabag::_bind_properties() {}
+void MessageQueueDatabag::_bind_methods() {}
 
 MessageQueueDatabag::MessageQueueDatabag() {
 	message_queue = MessageQueue::get_singleton();

--- a/godot/databags/godot_engine_databags.h
+++ b/godot/databags/godot_engine_databags.h
@@ -10,7 +10,7 @@ class MessageQueue;
 class FrameTime : public godex::Databag {
 	DATABAG(FrameTime)
 
-	static void _bind_properties();
+	static void _bind_methods();
 
 	// If set to true, the engine will shut down.
 	bool exit = false;
@@ -44,7 +44,7 @@ public:
 class OsDatabag : public godex::Databag {
 	DATABAG(OsDatabag)
 
-	static void _bind_properties();
+	static void _bind_methods();
 
 	OS *os_singleton;
 
@@ -58,7 +58,7 @@ public:
 class EngineDatabag : public godex::Databag {
 	DATABAG(EngineDatabag)
 
-	static void _bind_properties();
+	static void _bind_methods();
 
 	Engine *engine_singleton;
 
@@ -72,7 +72,7 @@ public:
 class MessageQueueDatabag : public godex::Databag {
 	DATABAG(MessageQueueDatabag)
 
-	static void _bind_properties();
+	static void _bind_methods();
 
 	MessageQueue *message_queue;
 

--- a/godot/databags/visual_servers_databags.cpp
+++ b/godot/databags/visual_servers_databags.cpp
@@ -11,7 +11,7 @@ RenderingServer *RenderingServerDatabag::get_rs() {
 	return rs;
 }
 
-void RenderingScenarioDatabag::_bind_properties() {
+void RenderingScenarioDatabag::_bind_methods() {
 	ECS_BIND_PROPERTY(RenderingScenarioDatabag, PropertyInfo(Variant::OBJECT, "scenario"), scenario);
 }
 

--- a/godot/databags/visual_servers_databags.h
+++ b/godot/databags/visual_servers_databags.h
@@ -23,7 +23,7 @@ class RenderingScenarioDatabag : public godex::Databag {
 	RID scenario;
 	bool changed = false;
 
-	static void _bind_properties();
+	static void _bind_methods();
 
 public:
 	void set_scenario(RID p_scenario_rid);

--- a/godot/nodes/ecs_world.h
+++ b/godot/nodes/ecs_world.h
@@ -143,8 +143,8 @@ class WorldECSCommands : public Object {
 protected:
 	static void _bind_methods();
 
-	DataAccessorScriptInstance<godex::Component> component_accessor;
-	DataAccessorScriptInstance<godex::Databag> databag_accessor;
+	DataAccessor<godex::Component> component_accessor;
+	DataAccessor<godex::Databag> databag_accessor;
 
 public:
 	WorldECSCommands();

--- a/godot/systems/physics_process_system.cpp
+++ b/godot/systems/physics_process_system.cpp
@@ -6,7 +6,7 @@
 #include "core/object/message_queue.h"
 #include "core/os/os.h"
 
-void Physics3DServerDatabag::_bind_properties() {
+void Physics3DServerDatabag::_bind_methods() {
 }
 
 Physics3DServerDatabag::Physics3DServerDatabag() {

--- a/godot/systems/physics_process_system.h
+++ b/godot/systems/physics_process_system.h
@@ -14,7 +14,7 @@ class MessageQueueDatabag;
 class Physics3DServerDatabag : public godex::Databag {
 	DATABAG(Physics3DServerDatabag)
 
-	static void _bind_properties();
+	static void _bind_methods();
 
 	PhysicsServer3D *physics_singleton;
 

--- a/iterators/dynamic_query.cpp
+++ b/iterators/dynamic_query.cpp
@@ -104,7 +104,7 @@ Object *DynamicQuery::get_access_gd(uint32_t p_index) {
 	return accessors.ptr() + p_index;
 }
 
-DataAccessorScriptInstance<godex::Component> *DynamicQuery::get_access(uint32_t p_index) {
+DataAccessor<godex::Component> *DynamicQuery::get_access(uint32_t p_index) {
 	ERR_FAIL_COND_V_MSG(is_valid() == false, nullptr, "The query is invalid.");
 	build();
 	return accessors.ptr() + p_index;

--- a/iterators/dynamic_query.h
+++ b/iterators/dynamic_query.h
@@ -22,7 +22,7 @@ class DynamicQuery : public Object {
 	LocalVector<bool> mutability;
 	LocalVector<bool> required;
 	LocalVector<uint32_t> reject_component_ids;
-	LocalVector<DataAccessorScriptInstance<Component>> accessors;
+	LocalVector<DataAccessor<Component>> accessors;
 	LocalVector<StorageBase *> storages;
 	LocalVector<StorageBase *> reject_storages;
 
@@ -57,7 +57,7 @@ public:
 	/// The returned pointer is valid only for the execution of the query.
 	/// If you reset the query, copy it (move the object), this pointer is invalidated.
 	Object *get_access_gd(uint32_t p_index);
-	DataAccessorScriptInstance<Component> *get_access(uint32_t p_index);
+	DataAccessor<Component> *get_access(uint32_t p_index);
 
 	/// Start the execution of this query.
 	void begin(World *p_world);

--- a/storage/storage.h
+++ b/storage/storage.h
@@ -37,6 +37,48 @@ public:
 	virtual void clear() {
 		CRASH_NOW_MSG("Override this function.");
 	}
+
+public:
+	// ~~ `DataAccessor` functions.
+	bool set(const StringName &p_name, const Variant &p_value) {
+		ERR_FAIL_V_MSG(false, "The storage `set` function does nothing.");
+	}
+
+	bool get(const StringName &p_name, Variant &r_value) const {
+		ERR_FAIL_V_MSG(false, "The storage `get` function does nothing.");
+	}
+
+	void call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) {
+		if (String(p_method) == "insert") { // TODO make this a static StringName to improve the check.
+			// Check argument count.
+			if (unlikely((p_argcount < 1) || (p_argcount > 2))) {
+				r_error.expected = 2;
+				r_error.argument = p_argcount;
+				r_error.error = p_argcount < 2 ? Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS : Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
+				ERR_FAIL_MSG("The function `Storage::insert` expects at least 1 argument.");
+			}
+
+#ifdef DEBUG_ENABLED
+			// Check argument validity
+			if (unlikely(
+						p_args[0] == nullptr ||
+						p_args[0]->get_type() != Variant::INT ||
+						(p_argcount == 2 &&
+								p_args[1] != nullptr &&
+								p_args[1]->get_type() != Variant::DICTIONARY))) {
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				ERR_FAIL_MSG("The `Storage::insert` arguments are: Entity ID (Int); (optional) component values (Dictionary).");
+			}
+#endif
+
+			insert_dynamic(
+					p_args[0]->operator unsigned int(),
+					(p_argcount == 2 && p_args[1] != nullptr) ? p_args[1]->operator Dictionary() : Dictionary());
+		}
+
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+		ERR_FAIL_MSG("The `Storage` doesn't have the method: " + p_method);
+	}
 };
 
 template <class T>

--- a/storage/storage.h
+++ b/storage/storage.h
@@ -64,8 +64,8 @@ public:
 						p_args[0] == nullptr ||
 						p_args[0]->get_type() != Variant::INT ||
 						(p_argcount == 2 &&
-								p_args[1] != nullptr &&
-								p_args[1]->get_type() != Variant::DICTIONARY))) {
+								(p_args[1] == nullptr ||
+										p_args[1]->get_type() != Variant::DICTIONARY)))) {
 				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				ERR_FAIL_MSG("The `Storage::insert` arguments are: Entity ID (Int); (optional) component values (Dictionary).");
 			}
@@ -74,10 +74,33 @@ public:
 			insert_dynamic(
 					p_args[0]->operator unsigned int(),
 					(p_argcount == 2 && p_args[1] != nullptr) ? p_args[1]->operator Dictionary() : Dictionary());
+
+		} else if (String(p_method) == "remove") { // TODO make this a static StringName to improve the check.
+			// Check argument count.
+			if (unlikely(p_argcount != 1)) {
+				r_error.expected = 1;
+				r_error.argument = p_argcount;
+				r_error.error = p_argcount < 1 ? Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS : Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
+				ERR_FAIL_MSG("The function `Storage::remove` expects just the enity ID (int).");
+			}
+
+#ifdef DEBUG_ENABLED
+			// Check argument validity
+			if (unlikely(
+						p_args[0] == nullptr ||
+						p_args[0]->get_type() != Variant::INT)) {
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				ERR_FAIL_MSG("The `Storage::remove` expects just the Entity ID (Int).");
+			}
+#endif
+
+			remove(p_args[0]->operator unsigned int());
+		} else {
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			ERR_FAIL_MSG("The `Storage` doesn't have the method: " + p_method);
 		}
 
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-		ERR_FAIL_MSG("The `Storage` doesn't have the method: " + p_method);
+		r_error.error = Callable::CallError::CALL_OK;
 	}
 };
 

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -59,10 +59,10 @@ class DynamicSystemInfo {
 	LocalVector<Variant *> access_ptr;
 
 	// Accessors databag.
-	LocalVector<DataAccessorScriptInstance<Databag>> databag_accessors;
+	LocalVector<DataAccessor<Databag>> databag_accessors;
 
 	// Accessors databag.
-	LocalVector<DataAccessorScriptInstance<StorageBase>> storage_accessors;
+	LocalVector<DataAccessor<StorageBase>> storage_accessors;
 
 	// ~~ Sub pipeline system ~~
 	func_system_execute_pipeline sub_pipeline_execute = nullptr;

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -47,9 +47,11 @@ class DynamicSystemInfo {
 
 	/// Map used to map the list of Databags to the script.
 	LocalVector<uint32_t> databag_element_map;
+	LocalVector<uint32_t> storage_element_map;
 	/// Map used to map the list of Components to the script.
 	LocalVector<uint32_t> query_element_map;
 	LocalVector<DDatabag> databags;
+	LocalVector<uint32_t> storages;
 	DynamicQuery query;
 
 	// Accessors.
@@ -58,6 +60,9 @@ class DynamicSystemInfo {
 
 	// Accessors databag.
 	LocalVector<DataAccessorScriptInstance<Databag>> databag_accessors;
+
+	// Accessors databag.
+	LocalVector<DataAccessorScriptInstance<StorageBase>> storage_accessors;
 
 	// ~~ Sub pipeline system ~~
 	func_system_execute_pipeline sub_pipeline_execute = nullptr;
@@ -73,6 +78,7 @@ public:
 	void with_component(uint32_t p_component_id, bool p_mutable);
 	void maybe_component(uint32_t p_component_id, bool p_mutable);
 	void without_component(uint32_t p_component_id);
+	void with_storage(uint32_t p_component_id);
 
 	void set_target(func_system_execute_pipeline p_sub_pipeline_execite);
 	void set_pipeline(Pipeline *p_pipeline);

--- a/tests/test_ecs_world.h
+++ b/tests/test_ecs_world.h
@@ -196,7 +196,7 @@ TEST_CASE("[Modules][ECS] Test storage script component") {
 TEST_CASE("[Modules][ECS] Test WorldECSCommands create entity from prefab.") {
 	World world;
 
-	DataAccessorScriptInstance<godex::Databag> world_access;
+	DataAccessor<godex::Databag> world_access;
 	world_access.__target = &world;
 	world_access.__mut = true;
 
@@ -231,7 +231,7 @@ TEST_CASE("[Modules][ECS] Test WorldECSCommands create entity from prefab.") {
 TEST_CASE("[Modules][ECS] Test WorldECSCommands fetch databags.") {
 	World world;
 
-	DataAccessorScriptInstance<godex::Databag> world_access;
+	DataAccessor<godex::Databag> world_access;
 	world_access.__target = &world;
 	world_access.__mut = true;
 

--- a/world/world.cpp
+++ b/world/world.cpp
@@ -12,14 +12,13 @@ const EntityBuilder &EntityBuilder::with(uint32_t p_component_id, const Dictiona
 	return *this;
 }
 
-void WorldCommands::_bind_properties() {
-	add_method("ret_mutable", &WorldCommands::ret_mutable);
-	add_method("ret_immutable", &WorldCommands::ret_immutable);
-	add_method("void_mutable", &WorldCommands::void_mutable);
-	add_method("void_immutable", &WorldCommands::void_immutable);
+void WorldCommands::_bind_methods() {
+	add_method("create_entity", &WorldCommands::create_entity);
+	add_method("destroy_deferred", &WorldCommands::destroy_deferred);
+	add_method("get_biggest_entity_id", &WorldCommands::get_biggest_entity_id);
 }
 
-EntityID WorldCommands::create_entity_index() {
+EntityID WorldCommands::create_entity() {
 	return entity_register++;
 }
 
@@ -49,7 +48,7 @@ World::World() {
 }
 
 EntityID World::create_entity_index() {
-	return commands.create_entity_index();
+	return commands.create_entity();
 }
 
 const EntityBuilder &World::create_entity() {

--- a/world/world.cpp
+++ b/world/world.cpp
@@ -12,6 +12,13 @@ const EntityBuilder &EntityBuilder::with(uint32_t p_component_id, const Dictiona
 	return *this;
 }
 
+void WorldCommands::_bind_properties() {
+	add_method("ret_mutable", &WorldCommands::ret_mutable);
+	add_method("ret_immutable", &WorldCommands::ret_immutable);
+	add_method("void_mutable", &WorldCommands::void_mutable);
+	add_method("void_immutable", &WorldCommands::void_immutable);
+}
+
 EntityID WorldCommands::create_entity_index() {
 	return entity_register++;
 }

--- a/world/world.h
+++ b/world/world.h
@@ -51,6 +51,90 @@ public:
 
 // TODO make this under godex namespace.
 
+#include "core/variant/binder_common.h"
+
+struct MethodHelperBase {
+	virtual int get_argument_count() const {
+		return 0;
+	}
+
+	virtual void call(void *p_obj, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) {}
+};
+
+template <class R, class C, class... Args, size_t... Is>
+void call_return_mutable(C *p_obj, R (C::*method)(Args...), const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
+	*r_ret = (p_obj->*method)(VariantCaster<Args>::cast(*p_args[Is])...);
+}
+
+template <class R, class C, class... Args>
+struct MethodHelperR : public MethodHelperBase {
+	R(C::*method)
+	(Args...);
+
+	virtual int get_argument_count() const override {
+		return int(sizeof...(Args));
+	}
+
+	virtual void call(void *p_obj, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) override {
+		call_return_mutable(static_cast<C *>(p_obj), method, p_args, p_argcount, r_ret, r_error, BuildIndexSequence<sizeof...(Args)>{});
+	}
+};
+
+template <class R, class C, class... Args, size_t... Is>
+void call_return_immutable(const C *p_obj, R (C::*method)(Args...) const, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
+	*r_ret = (p_obj->*method)(VariantCaster<Args>::cast(*p_args[Is])...);
+}
+
+template <class R, class C, class... Args>
+struct MethodHelperRC : public MethodHelperBase {
+	R(C::*method)
+	(Args...) const;
+
+	virtual int get_argument_count() const override {
+		return int(sizeof...(Args));
+	}
+
+	virtual void call(void *p_obj, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) override {
+		call_return_immutable(static_cast<const C *>(p_obj), method, p_args, p_argcount, r_ret, r_error, BuildIndexSequence<sizeof...(Args)>{});
+	}
+};
+
+template <class C, class... Args, size_t... Is>
+void call_rvoid_mutable(C *p_obj, void (C::*method)(Args...), const Variant **p_args, int p_argcount, Callable::CallError &r_error, IndexSequence<Is...>) {
+	(p_obj->*method)(VariantCaster<Args>::cast(*p_args[Is])...);
+}
+
+template <class C, class... Args>
+struct MethodHelper : public MethodHelperBase {
+	void (C::*method)(Args...);
+
+	virtual int get_argument_count() const override {
+		return int(sizeof...(Args));
+	}
+
+	virtual void call(void *p_obj, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) override {
+		call_rvoid_mutable(static_cast<C *>(p_obj), method, p_args, p_argcount, r_error, BuildIndexSequence<sizeof...(Args)>{});
+	}
+};
+
+template <class C, class... Args, size_t... Is>
+void call_rvoid_immutable(const C *p_obj, void (C::*method)(Args...) const, const Variant **p_args, int p_argcount, Callable::CallError &r_error, IndexSequence<Is...>) {
+	(p_obj->*method)(VariantCaster<Args>::cast(*p_args[Is])...);
+}
+
+template <class C, class... Args>
+struct MethodHelperC : public MethodHelperBase {
+	void (C::*method)(Args...) const;
+
+	virtual int get_argument_count() const override {
+		return int(sizeof...(Args));
+	}
+
+	virtual void call(void *p_obj, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) override {
+		call_rvoid_immutable(static_cast<const C *>(p_obj), method, p_args, p_argcount, r_error, BuildIndexSequence<sizeof...(Args)>{});
+	}
+};
+
 // TODO consider to split this in multiple `Databag`, one for removal and the
 // other for creation. So two `Systems` can run in parallel.
 class WorldCommands : public godex::Databag {
@@ -65,6 +149,69 @@ class WorldCommands : public godex::Databag {
 	LocalVector<EntityID> garbage_list;
 
 public:
+	static void _bind_properties();
+
+	EntityID ret_mutable(int p_aa) { return EntityID(); }
+	EntityID ret_immutable(int p_aa) const { return EntityID(); }
+	void void_mutable(int p_aa) {}
+	void void_immutable(int p_aa) const {}
+
+	static inline LocalVector<StringName> methods_map;
+	static inline LocalVector<MethodHelperBase *> methods;
+
+	/// Adds methods with a return type.
+	template <class R, class C, class... Args>
+	static void add_method(const StringName &p_method, R (C::*method)(Args...)) {
+		ERR_FAIL_COND_MSG(methods_map.find(p_method) >= 0, "The method " + p_method + " is already registered: " + get_class_static());
+		methods_map.push_back(p_method);
+		methods.push_back(new MethodHelperR<R, C, Args...>());
+	}
+
+	/// Adds methods with a return type and constants.
+	template <class R, class C, class... Args>
+	static void add_method(const StringName &p_method, R (C::*method)(Args...) const) {
+		ERR_FAIL_COND_MSG(methods_map.find(p_method) >= 0, "The method " + p_method + " is already registered: " + get_class_static());
+		methods_map.push_back(p_method);
+		methods.push_back(new MethodHelperRC<R, C, Args...>());
+	}
+
+	/// Adds methods without a return type.
+	template <class C, class... Args>
+	static void add_method(const StringName &p_method, void (C::*method)(Args...)) {
+		ERR_FAIL_COND_MSG(methods_map.find(p_method) >= 0, "The method " + p_method + " is already registered: " + get_class_static());
+		methods_map.push_back(p_method);
+		methods.push_back(new MethodHelper<C, Args...>());
+	}
+
+	/// Adds methods without a return type and constants.
+	template <class C, class... Args>
+	static void add_method(const StringName &p_method, void (C::*method)(Args...) const) {
+		ERR_FAIL_COND_MSG(methods_map.find(p_method) >= 0, "The method " + p_method + " is already registered: " + get_class_static());
+		methods_map.push_back(p_method);
+		methods.push_back(new MethodHelperC<C, Args...>());
+	}
+
+	void call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) {
+		const uint32_t index = methods_map.find(p_method);
+		if (unlikely(index < 0)) {
+			ERR_PRINT("The method " + p_method + " is unknown " + get_class_static());
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			return;
+		}
+		if (unlikely(methods[index]->get_argument_count() != p_argcount)) {
+			ERR_PRINT("The method " + p_method + " is has " + itos(methods[index]->get_argument_count()) + " arguments; provided: " + itos(p_argcount) + " - " + get_class_static());
+			if (methods[index]->get_argument_count() > p_argcount) {
+				r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
+			} else {
+				r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
+			}
+			r_error.argument = p_argcount;
+			r_error.expected = methods[index]->get_argument_count();
+			return;
+		}
+		methods[index]->call(this, p_args, p_argcount, r_ret, r_error);
+	}
+
 	/// Immediately creates a new `Entity`.
 	EntityID create_entity_index();
 


### PR DESCRIPTION
Closes #35
Closes #31

- Exposed `Databag`s and `Component`s methods to scripts.
- Renamed `_bind_properties` to `_bind_method`, so to match Godot syntax.
- Storage class exposed to GDScript (+ tests)
Now it's possible to `insert` Components from script.
- Exposed storage remove (+ tests)
Now it's possible to `remove` Components from script.
- Renamed `DataAccessorScriptInstance` to `DataAccessor`
