### PR TITLE
Remove WorldECSCommands to simplify the API

### DIFF
--- a/ecs.h
+++ b/ecs.h
@@ -11,6 +11,7 @@
 #include "systems/system_builder.h"
 
 class World;
+class WorldECS;
 class Pipeline;
 class DynamicComponentInfo;
 
@@ -56,10 +57,11 @@ class ECS : public Object {
 	static LocalVector<StringName> systems;
 	static LocalVector<SystemInfo> systems_info;
 
+	// Node used by GDScript.
+	WorldECS *active_world_node = nullptr;
 	World *active_world = nullptr;
 	Pipeline *active_world_pipeline = nullptr;
 	bool dispatching = false;
-	DataAccessor<godex::Databag> world_access;
 
 public:
 	// ~~ Components ~~
@@ -151,9 +153,9 @@ public:
 
 	/// Set the active world. If there is already an active world an error
 	/// is generated.
-	void set_active_world(World *p_world);
+	void set_active_world(World *p_world, WorldECS *p_active_world_ecs);
 	World *get_active_world() const;
-	Object *get_active_world_gds();
+	Node *get_active_world_node();
 
 	bool has_active_world() const;
 

--- a/godot/nodes/ecs_utilities.cpp
+++ b/godot/nodes/ecs_utilities.cpp
@@ -9,6 +9,7 @@
 
 void System::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("with_databag", "databag_name", "mutability"), &System::with_databag);
+	ClassDB::bind_method(D_METHOD("with_storage", "component_name"), &System::with_storage);
 	ClassDB::bind_method(D_METHOD("with_component", "component_name", "mutability"), &System::with_component);
 	ClassDB::bind_method(D_METHOD("maybe_component", "component_name", "mutability"), &System::maybe_component);
 	ClassDB::bind_method(D_METHOD("without_component", "component_name"), &System::without_component);
@@ -54,6 +55,12 @@ void System::with_databag(const StringName &p_databag, Mutability p_mutability) 
 	ERR_FAIL_COND_MSG(prepare_in_progress == false, "No info set. This function can be called only within the `_prepare`.");
 	const godex::databag_id id = ECS::get_databag_id(p_databag);
 	info->with_databag(id, p_mutability == MUTABLE);
+}
+
+void System::with_storage(const StringName &p_component_name) {
+	ERR_FAIL_COND_MSG(prepare_in_progress == false, "No info set. This function can be called only within the `_prepare`.");
+	const godex::component_id id = ECS::get_component_id(p_component_name);
+	info->with_storage(id);
 }
 
 void System::with_component(const StringName &p_component, Mutability p_mutability) {

--- a/godot/nodes/ecs_utilities.h
+++ b/godot/nodes/ecs_utilities.h
@@ -34,6 +34,7 @@ public:
 	~System();
 
 	void with_databag(const StringName &p_databag_name, Mutability p_mutability);
+	void with_storage(const StringName &p_component_name);
 	void with_component(const StringName &p_component_name, Mutability p_mutability);
 	void maybe_component(const StringName &p_component_name, Mutability p_mutability);
 	void without_component(const StringName &p_component_name);

--- a/godot/nodes/ecs_world.h
+++ b/godot/nodes/ecs_world.h
@@ -129,45 +129,35 @@ public:
 	void set_active_pipeline(StringName p_name);
 	StringName get_active_pipeline() const;
 
+	// ~~ Runtime API ~~
 private:
-	void active_world();
-	void unactive_world();
-};
-
-// TODO remove this and handle directly via storages and WorldCommands.
-/// World Manipulatort
-class WorldECSCommands : public Object {
-	GDCLASS(WorldECSCommands, Object)
-	SINGLETON_MAKER(WorldECSCommands)
-
-protected:
-	static void _bind_methods();
-
 	DataAccessor<godex::Component> component_accessor;
 	DataAccessor<godex::Databag> databag_accessor;
 
 public:
-	WorldECSCommands();
-
-	uint32_t create_entity(Object *p_world);
-	void destroy_entity(Object *p_world, uint32_t p_entity_id);
+	uint32_t create_entity();
+	void destroy_entity(uint32_t p_entity_id);
 
 	/// Creates an entity coping the components from the given `Entity`.
-	uint32_t create_entity_from_prefab(Object *p_world, Object *p_entity);
+	uint32_t create_entity_from_prefab(Object *p_entity);
 
-	void add_component(Object *p_world, uint32_t entity_id, const StringName &p_component_name, const Dictionary &p_data);
-	void add_component_by_id(Object *p_world, uint32_t entity_id, uint32_t p_component_id, const Dictionary &p_data);
+	void add_component(uint32_t entity_id, const StringName &p_component_name, const Dictionary &p_data);
+	void add_component_by_id(uint32_t entity_id, uint32_t p_component_id, const Dictionary &p_data);
 
-	void remove_component(Object *p_world, uint32_t entity_id, const StringName &p_component_name);
-	void remove_component_by_id(Object *p_world, uint32_t entity_id, uint32_t p_component_id);
+	void remove_component(uint32_t entity_id, const StringName &p_component_name);
+	void remove_component_by_id(uint32_t entity_id, uint32_t p_component_id);
 
 	/// Returns the component of the entity or null if not assigned.
 	/// The returned object lifetime is short, never store it.
-	Object *get_entity_component(Object *p_world, uint32_t entity_id, const StringName &p_component_name);
-	Object *get_entity_component_by_id(Object *p_world, uint32_t entity_id, uint32_t p_component_id);
+	Object *get_entity_component(uint32_t entity_id, const StringName &p_component_name);
+	Object *get_entity_component_by_id(uint32_t entity_id, uint32_t p_component_id);
 
 	/// Returns the databag or null if not present in the world.
 	/// The returned object lifetime is short, never store it.
-	Object *get_databag(Object *p_world, const StringName &p_databag_name);
-	Object *get_databag_by_id(Object *p_world, uint32_t p_databag_id);
+	Object *get_databag(const StringName &p_databag_name);
+	Object *get_databag_by_id(uint32_t p_databag_id);
+
+private:
+	void active_world();
+	void unactive_world();
 };

--- a/godot/nodes/entity.cpp
+++ b/godot/nodes/entity.cpp
@@ -17,6 +17,8 @@ void Entity::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_component_value", "component", "property", "value"), &Entity::set_component_value);
 	ClassDB::bind_method(D_METHOD("get_component_value", "component", "property"), &Entity::get_component_value);
 
+	ClassDB::bind_method(D_METHOD("clone", "world"), &Entity::clone);
+
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "__component_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "__set_components_data", "__get_components_data");
 }
 
@@ -305,6 +307,13 @@ bool Entity::_get_component(StringName p_component_name, Variant &r_ret) const {
 		r_ret = dic;
 		return true;
 	}
+}
+
+uint32_t Entity::clone(Object *p_world) const {
+	WorldECS *world = Object::cast_to<WorldECS>(p_world);
+	ERR_FAIL_COND_V_MSG(world == nullptr, EntityID(), "The passed object is not a `WorldECS`.");
+	ERR_FAIL_COND_V_MSG(world->get_world() == nullptr, EntityID(), "This world doesn't have the ECS world.");
+	return _create_entity(world->get_world());
 }
 
 void Entity::create_entity() {

--- a/godot/nodes/entity.h
+++ b/godot/nodes/entity.h
@@ -12,7 +12,7 @@ class World;
 class Entity : public Node {
 	GDCLASS(Entity, Node);
 
-	friend class WorldECSCommands;
+	friend class WorldECS;
 
 	EntityID entity_id;
 	Dictionary components_data;
@@ -42,6 +42,9 @@ public:
 
 	bool set_component(StringName p_component_name, const Variant &d_ret);
 	bool _get_component(StringName p_component_name, Variant &r_ret) const;
+
+	/// Duplicate this `Entity`.
+	uint32_t clone(Object *p_world) const;
 
 private:
 	void create_entity();

--- a/iterators/dynamic_query.cpp
+++ b/iterators/dynamic_query.cpp
@@ -1,6 +1,7 @@
 #include "dynamic_query.h"
 
 #include "../ecs.h"
+#include "../godot/nodes/ecs_world.h"
 
 using godex::DynamicQuery;
 
@@ -111,9 +112,9 @@ DataAccessor<godex::Component> *DynamicQuery::get_access(uint32_t p_index) {
 }
 
 void DynamicQuery::begin_script(Object *p_world) {
-	World *world = godex::unwrap_databag<World>(p_world);
-	ERR_FAIL_COND_MSG(world == nullptr, "The given object is not a `World` `Databag`.");
-	begin(world);
+	WorldECS *world = Object::cast_to<WorldECS>(p_world);
+	ERR_FAIL_COND_MSG(world == nullptr, "The given object is not a `WorldECS`.");
+	begin(world->get_world());
 }
 
 void DynamicQuery::begin(World *p_world) {

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -95,14 +95,6 @@ void register_godex_types() {
 		create_physics_system_dispatcher(ECS::get_dynamic_system_info(id));
 	}
 	ECS::register_system(step_physics_server_3d, "StepPhysicsServer3D", "Steps the PhysicsServer3D.");
-
-	// ~~ Register Godot singleton ~~
-	// NOTE: These singleton doesn't store data but are here only to provide
-	// access to functionalities. This enforces the separation between data and
-	// functions.
-	// TODO improve this, maybe propose to GODOT to add `static functions`
-	// access?
-	WorldECSCommands::get_singleton();
 }
 
 void unregister_godex_types() {

--- a/tests/test_ecs_world.h
+++ b/tests/test_ecs_world.h
@@ -193,12 +193,8 @@ TEST_CASE("[Modules][ECS] Test storage script component") {
 	}
 }
 
-TEST_CASE("[Modules][ECS] Test WorldECSCommands create entity from prefab.") {
-	World world;
-
-	DataAccessor<godex::Databag> world_access;
-	world_access.__target = &world;
-	world_access.__mut = true;
+TEST_CASE("[Modules][ECS] Test WorldECS runtime API create entity from prefab.") {
+	WorldECS world;
 
 	Entity entity_prefab;
 
@@ -206,17 +202,14 @@ TEST_CASE("[Modules][ECS] Test WorldECSCommands create entity from prefab.") {
 	defaults["transform"] = Transform(Basis(), Vector3(10.0, 0.0, 0.0));
 	entity_prefab.add_component("TransformComponent", defaults);
 
-	const uint32_t entity_id = WorldECSCommands::get_singleton()->create_entity_from_prefab(
-			&world_access,
-			&entity_prefab);
+	const uint32_t entity_id = world.create_entity_from_prefab(&entity_prefab);
 
 	// Make sure something is created.
 	CHECK(entity_id != UINT32_MAX);
 
 	// Make sure the component is created
 
-	Object *comp = WorldECSCommands::get_singleton()->get_entity_component(
-			&world_access,
+	Object *comp = world.get_entity_component(
 			entity_id,
 			"TransformComponent");
 
@@ -228,21 +221,15 @@ TEST_CASE("[Modules][ECS] Test WorldECSCommands create entity from prefab.") {
 	CHECK(ABS(transf->get_transform().origin.x - 10) <= CMP_EPSILON);
 }
 
-TEST_CASE("[Modules][ECS] Test WorldECSCommands fetch databags.") {
-	World world;
+TEST_CASE("[Modules][ECS] Test WorldECS runtime API fetch databags.") {
+	WorldECS world;
 
-	DataAccessor<godex::Databag> world_access;
-	world_access.__target = &world;
-	world_access.__mut = true;
-
-	Object *world_res_raw = WorldECSCommands::get_singleton()->get_databag(
-			&world_access,
-			"World");
+	Object *world_res_raw = world.get_databag("World");
 
 	CHECK(world_res_raw != nullptr);
 
 	World *world_ptr = godex::unwrap_databag<World>(world_res_raw);
-	CHECK(&world == world_ptr);
+	CHECK(world.get_world() == world_ptr);
 }
 
 } // namespace godex_tests_world

--- a/world/world.cpp
+++ b/world/world.cpp
@@ -34,6 +34,9 @@ EntityID WorldCommands::get_biggest_entity_id() const {
 	}
 }
 
+void World::_bind_methods() {
+}
+
 World::World() {
 	// Add self as databag, so that the `Systems` can obtain it.
 	const uint32_t size = MAX(WorldCommands::get_databag_id(), World::get_databag_id()) + 1;

--- a/world/world.h
+++ b/world/world.h
@@ -64,9 +64,9 @@ class WorldCommands : public godex::Databag {
 	/// List of `Entity` to destroy.
 	LocalVector<EntityID> garbage_list;
 
-public:
 	static void _bind_methods();
 
+public:
 	/// Immediately creates a new `Entity`.
 	EntityID create_entity();
 
@@ -88,6 +88,8 @@ class World : public godex::Databag {
 	LocalVector<StorageBase *> storages;
 	LocalVector<godex::Databag *> databags;
 	EntityBuilder entity_builder = EntityBuilder(this);
+
+	static void _bind_methods();
 
 public:
 	World();


### PR DESCRIPTION
Closes #34

- Remove WorldECSCommands to simplify the API
- Exposed `add_storage` to gdscript `System` (for storage manipulation)
- `DynamicQuery` is now using `WorldECS` to access the world from GDScript.