### PR TITLE
Integrated Entity node parenting

### DIFF
--- a/ecs.cpp
+++ b/ecs.cpp
@@ -30,6 +30,7 @@ void ECS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("verify_system_id", "name"), &ECS::verify_system_id_obj);
 
 	ADD_SIGNAL(MethodInfo("world_loaded"));
+	ADD_SIGNAL(MethodInfo("world_ready"));
 	ADD_SIGNAL(MethodInfo("world_pre_unload"));
 	ADD_SIGNAL(MethodInfo("world_unloaded"));
 }
@@ -278,13 +279,19 @@ void ECS::set_active_world(World *p_world, WorldECS *p_active_world_ecs) {
 	if (active_world != nullptr) {
 		// The world is just loaded.
 		emit_signal("world_loaded");
+		// Ready.
+		emit_signal("world_ready");
 	} else {
 		// The world is just unloaded.
 		emit_signal("world_unloaded");
 	}
 }
 
-World *ECS::get_active_world() const {
+World *ECS::get_active_world() {
+	return active_world;
+}
+
+const World *ECS::get_active_world() const {
 	return active_world;
 }
 

--- a/ecs.h
+++ b/ecs.h
@@ -50,6 +50,15 @@ class ECS : public Object {
 
 	friend class Main;
 
+public:
+	enum {
+		NOTIFICATION_ECS_LOADED = -1,
+		NOTIFICATION_ECS_WORLD_PRE_UNLOAD = -2,
+		NOTIFICATION_ECS_UNLOADED = -3,
+		NOTIFICATION_ECS_WORDL_READY = -4
+	};
+
+private:
 	static ECS *singleton;
 	static LocalVector<StringName> components;
 	static LocalVector<ComponentInfo> components_info;
@@ -63,6 +72,7 @@ class ECS : public Object {
 	// Node used by GDScript.
 	WorldECS *active_world_node = nullptr;
 	World *active_world = nullptr;
+	bool ready = false;
 	Pipeline *active_world_pipeline = nullptr;
 	bool dispatching = false;
 
@@ -179,6 +189,7 @@ public:
 	Node *get_active_world_node();
 
 	bool has_active_world() const;
+	bool is_world_ready() const;
 
 	void set_active_world_pipeline(Pipeline *p_pipeline);
 	Pipeline *get_active_world_pipeline() const;

--- a/ecs.h
+++ b/ecs.h
@@ -174,7 +174,8 @@ public:
 	/// Set the active world. If there is already an active world an error
 	/// is generated.
 	void set_active_world(World *p_world, WorldECS *p_active_world_ecs);
-	World *get_active_world() const;
+	World *get_active_world();
+	const World *get_active_world() const;
 	Node *get_active_world_node();
 
 	bool has_active_world() const;

--- a/godot/components/child.cpp
+++ b/godot/components/child.cpp
@@ -1,0 +1,6 @@
+#include "child.h"
+
+void Child::_bind_methods() {
+	// Don't expose this to editor. It's automatically resolved at runtime.
+	//ECS_BIND_PROPERTY(Child, PropertyInfo(Variant::INT, "parent"), parent);
+}

--- a/godot/components/child.cpp
+++ b/godot/components/child.cpp
@@ -1,6 +1,13 @@
 #include "child.h"
 
 void Child::_bind_methods() {
-	// Don't expose this to editor. It's automatically resolved at runtime.
-	//ECS_BIND_PROPERTY(Child, PropertyInfo(Variant::INT, "parent"), parent);
+	// TODO don't expose to editor but allow fetch this from scripts.
+	ECS_BIND_PROPERTY(Child, PropertyInfo(Variant::INT, "parent"), parent);
+}
+
+Child::Child() {
+}
+
+Child::Child(EntityID p_parent) :
+		parent(p_parent) {
 }

--- a/godot/components/child.h
+++ b/godot/components/child.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../../components/component.h"
+
+class Child : public godex::Component {
+	COMPONENT(Child, DenseVectorStorage)
+
+	static void _bind_methods();
+
+public:
+	EntityID parent;
+};

--- a/godot/components/child.h
+++ b/godot/components/child.h
@@ -9,4 +9,7 @@ class Child : public godex::Component {
 
 public:
 	EntityID parent;
+
+	Child();
+	Child(EntityID p_parent);
 };

--- a/godot/nodes/entity.cpp
+++ b/godot/nodes/entity.cpp
@@ -1,6 +1,32 @@
 
 #include "entity.h"
 
+EntityBase *EntityBase::get_node_entity_base(Node *p_node) {
+	Entity3D *entity_3d = Object::cast_to<Entity3D>(p_node);
+	if (entity_3d == nullptr) {
+		Entity2D *entity_2d = Object::cast_to<Entity2D>(p_node);
+		if (entity_2d == nullptr) {
+			return nullptr;
+		}
+		return &entity_2d->get_internal_entity_base();
+	}
+	return &entity_3d->get_internal_entity_base();
+}
+
+void EntityBase::add_child(EntityID p_entity_id) {
+	ERR_FAIL_COND_MSG(entity_id.is_null(), "The entity_id is not supposed to be null.");
+	ERR_FAIL_COND_MSG(p_entity_id.is_null(), "The passed entity_id is not supposed to be null.");
+
+	ECS::get_singleton()->get_active_world()->add_component<Child>(p_entity_id, Child(entity_id));
+}
+
+void EntityBase::remove_child(EntityID p_entity_id) {
+	ERR_FAIL_COND_MSG(entity_id.is_null(), "The entity_id is not supposed to be null.");
+	ERR_FAIL_COND_MSG(p_entity_id.is_null(), "The passed entity_id is not supposed to be null.");
+
+	ECS::get_singleton()->get_active_world()->remove_component<Child>(p_entity_id);
+}
+
 void Entity3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("__set_components_data", "data"), &Entity3D::set_components_data);
 	ClassDB::bind_method(D_METHOD("__get_components_data"), &Entity3D::get_components_data);

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -8,6 +8,7 @@
 #include "iterators/dynamic_query.h"
 #include "systems/dynamic_system.h"
 
+#include "godot/components/child.h"
 #include "godot/components/mesh_component.h"
 #include "godot/components/physics/shape_3d_component.h"
 #include "godot/components/transform_component.h"
@@ -74,12 +75,13 @@ void register_godex_types() {
 		MessageQueue::get_singleton()->push_callable(callable_mp(&rep, &REP::setup_ecs));
 	}
 
-	// ~ Register engine components ~
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Register engine components
+	ECS::register_component<Child>();
 	ECS::register_component<MeshComponent>();
 	ECS::register_component<TransformComponent>();
 	ECS::register_component<Shape3DComponent>();
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Register engine databags
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Register engine databags
 	ECS::register_databag<WorldCommands>();
 	ECS::register_databag<World>();
 


### PR DESCRIPTION
Associated proposal: https://github.com/GodotECS/godex/issues/28

This PR integrates the `Entity` node parenting mechanism:

Now it's possible to add `Child` `Component` to the `Entity`:
![Screenshot from 2021-01-26 11-54-00](https://user-images.githubusercontent.com/8342599/105836402-673e4280-5fcd-11eb-93b2-6c814abebc3b.png)

The `Child` has the property `parent` that contains the index of the parent `Entity`.

If the `Entity` has the `Child` `Component` and its parent is another `Entity`, the `Child.parent` property is filled automatically at runtime.
![Screenshot from 2021-01-26 11-53-44](https://user-images.githubusercontent.com/8342599/105836306-47a71a00-5fcd-11eb-8b32-bacd5434b2b7.png)

In other word, to compose the hierarchy, is enough parent the `Entity` node and assign the `Child` `Component` to the parented `Entities`.
![ezgif com-video-to-gif(6)](https://user-images.githubusercontent.com/8342599/105837211-a7ea8b80-5fce-11eb-959f-79580611b311.gif)


