### PR TITLE
Improved ECS API syntax and exposed some functionalities. 

### DIFF
--- a/ecs.cpp
+++ b/ecs.cpp
@@ -404,6 +404,9 @@ uint32_t ECS::register_script_component(const StringName &p_name, const LocalVec
 					nullptr,
 					info });
 
+	// Add a new scripting constant, for fast and easy `component` access.
+	ClassDB::bind_integer_constant(get_class_static(), StringName(), String(p_name).replace(".", "_"), info->component_id);
+
 	print_line("ComponentScript: " + p_name + " registered with ID: " + itos(info->component_id));
 
 	return info->component_id;

--- a/ecs.h
+++ b/ecs.h
@@ -241,6 +241,9 @@ void ECS::register_component() {
 					&C::create_storage_no_type,
 					nullptr });
 
+	// Add a new scripting constant, for fast and easy `component` access.
+	ClassDB::bind_integer_constant(get_class_static(), StringName(), component_name, C::component_id);
+
 	print_line("Component: " + component_name + " registered with ID: " + itos(C::component_id));
 }
 
@@ -267,4 +270,7 @@ void ECS::register_databag() {
 	databags.push_back(databag_name);
 	databags_info.push_back(DatabagInfo{
 			R::create_databag_no_type });
+
+	// Add a new scripting constant, for fast and easy `databag` access.
+	ClassDB::bind_integer_constant(get_class_static(), StringName(), databag_name, R::databag_id);
 }

--- a/godot/nodes/ecs_utilities.cpp
+++ b/godot/nodes/ecs_utilities.cpp
@@ -8,11 +8,11 @@
 #include "core/object/script_language.h"
 
 void System::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("with_databag", "databag_name", "mutability"), &System::with_databag);
-	ClassDB::bind_method(D_METHOD("with_storage", "component_name"), &System::with_storage);
-	ClassDB::bind_method(D_METHOD("with_component", "component_name", "mutability"), &System::with_component);
-	ClassDB::bind_method(D_METHOD("maybe_component", "component_name", "mutability"), &System::maybe_component);
-	ClassDB::bind_method(D_METHOD("without_component", "component_name"), &System::without_component);
+	ClassDB::bind_method(D_METHOD("with_databag", "databag_id", "mutability"), &System::with_databag);
+	ClassDB::bind_method(D_METHOD("with_storage", "component_id"), &System::with_storage);
+	ClassDB::bind_method(D_METHOD("with_component", "component_id", "mutability"), &System::with_component);
+	ClassDB::bind_method(D_METHOD("maybe_component", "component_id", "mutability"), &System::maybe_component);
+	ClassDB::bind_method(D_METHOD("without_component", "component_id"), &System::without_component);
 
 	ClassDB::bind_method(D_METHOD("get_current_entity_id"), &System::get_current_entity_id);
 
@@ -51,34 +51,29 @@ System::~System() {
 	}
 }
 
-void System::with_databag(const StringName &p_databag, Mutability p_mutability) {
+void System::with_databag(uint32_t p_databag_id, Mutability p_mutability) {
 	ERR_FAIL_COND_MSG(prepare_in_progress == false, "No info set. This function can be called only within the `_prepare`.");
-	const godex::databag_id id = ECS::get_databag_id(p_databag);
-	info->with_databag(id, p_mutability == MUTABLE);
+	info->with_databag(p_databag_id, p_mutability == MUTABLE);
 }
 
-void System::with_storage(const StringName &p_component_name) {
+void System::with_storage(uint32_t p_component_id) {
 	ERR_FAIL_COND_MSG(prepare_in_progress == false, "No info set. This function can be called only within the `_prepare`.");
-	const godex::component_id id = ECS::get_component_id(p_component_name);
-	info->with_storage(id);
+	info->with_storage(p_component_id);
 }
 
-void System::with_component(const StringName &p_component, Mutability p_mutability) {
+void System::with_component(uint32_t p_component_id, Mutability p_mutability) {
 	ERR_FAIL_COND_MSG(prepare_in_progress == false, "No info set. This function can be called only within the `_prepare`.");
-	const godex::component_id id = ECS::get_component_id(p_component);
-	info->with_component(id, p_mutability == MUTABLE);
+	info->with_component(p_component_id, p_mutability == MUTABLE);
 }
 
-void System::maybe_component(const StringName &p_component, Mutability p_mutability) {
+void System::maybe_component(uint32_t p_component_id, Mutability p_mutability) {
 	ERR_FAIL_COND_MSG(prepare_in_progress == false, "No info set. This function can be called only within the `_prepare`.");
-	const godex::component_id id = ECS::get_component_id(p_component);
-	info->maybe_component(id, p_mutability == MUTABLE);
+	info->maybe_component(p_component_id, p_mutability == MUTABLE);
 }
 
-void System::without_component(const StringName &p_component) {
+void System::without_component(uint32_t p_component_id) {
 	ERR_FAIL_COND_MSG(prepare_in_progress == false, "No info set. This function can be called only within the `_prepare`.");
-	const godex::component_id id = ECS::get_component_id(p_component);
-	info->without_component(id);
+	info->without_component(p_component_id);
 }
 
 godex::system_id System::get_system_id() const {

--- a/godot/nodes/ecs_utilities.h
+++ b/godot/nodes/ecs_utilities.h
@@ -33,11 +33,11 @@ public:
 	System();
 	~System();
 
-	void with_databag(const StringName &p_databag_name, Mutability p_mutability);
-	void with_storage(const StringName &p_component_name);
-	void with_component(const StringName &p_component_name, Mutability p_mutability);
-	void maybe_component(const StringName &p_component_name, Mutability p_mutability);
-	void without_component(const StringName &p_component_name);
+	void with_databag(uint32_t p_databag_id, Mutability p_mutability);
+	void with_storage(uint32_t p_component_id);
+	void with_component(uint32_t p_component_id, Mutability p_mutability);
+	void maybe_component(uint32_t p_component_id, Mutability p_mutability);
+	void without_component(uint32_t p_component_id);
 
 	godex::system_id get_system_id() const;
 

--- a/godot/nodes/ecs_world.cpp
+++ b/godot/nodes/ecs_world.cpp
@@ -154,20 +154,20 @@ void WorldECS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("create_entity_from_prefab", "entity_node"), &WorldECS::create_entity_from_prefab);
 
-	ClassDB::bind_method(D_METHOD("add_component", "component_name", "data"), &WorldECS::add_component);
-	ClassDB::bind_method(D_METHOD("add_component_by_id", "component_id", "data"), &WorldECS::add_component_by_id);
+	ClassDB::bind_method(D_METHOD("add_component_by_name", "component_name", "data"), &WorldECS::add_component_by_name);
+	ClassDB::bind_method(D_METHOD("add_component", "component_id", "data"), &WorldECS::add_component);
 
-	ClassDB::bind_method(D_METHOD("remove_component", "component_name", "data"), &WorldECS::remove_component);
-	ClassDB::bind_method(D_METHOD("remove_component_by_id", "component_id", "data"), &WorldECS::remove_component_by_id);
+	ClassDB::bind_method(D_METHOD("remove_component_by_name", "component_name", "data"), &WorldECS::remove_component_by_name);
+	ClassDB::bind_method(D_METHOD("remove_component", "component_id", "data"), &WorldECS::remove_component);
 
-	ClassDB::bind_method(D_METHOD("get_entity_component", "entity_id", "component_name"), &WorldECS::get_entity_component);
-	ClassDB::bind_method(D_METHOD("get_entity_component_by_id", "entity_id", "component_id"), &WorldECS::get_entity_component_by_id);
+	ClassDB::bind_method(D_METHOD("get_entity_component_by_name", "entity_id", "component_name"), &WorldECS::get_entity_component_by_name);
+	ClassDB::bind_method(D_METHOD("get_entity_component", "entity_id", "component_id"), &WorldECS::get_entity_component);
 
-	ClassDB::bind_method(D_METHOD("has_entity_component", "entity_id", "component_name"), &WorldECS::has_entity_component);
-	ClassDB::bind_method(D_METHOD("has_entity_component_by_id", "entity_id", "component_id"), &WorldECS::has_entity_component_by_id);
+	ClassDB::bind_method(D_METHOD("has_entity_component_by_name", "entity_id", "component_name"), &WorldECS::has_entity_component_by_name);
+	ClassDB::bind_method(D_METHOD("has_entity_component", "entity_id", "component_id"), &WorldECS::has_entity_component);
 
+	ClassDB::bind_method(D_METHOD("get_databag_by_name", "databag_name"), &WorldECS::get_databag_by_name);
 	ClassDB::bind_method(D_METHOD("get_databag", "databag_name"), &WorldECS::get_databag);
-	ClassDB::bind_method(D_METHOD("get_databag_by_id", "databag_name"), &WorldECS::get_databag_by_id);
 }
 
 bool WorldECS::_set(const StringName &p_name, const Variant &p_value) {
@@ -416,34 +416,34 @@ uint32_t WorldECS::create_entity_from_prefab(Object *p_entity) {
 	return entity->_create_entity(world);
 }
 
-void WorldECS::add_component(uint32_t entity_id, const StringName &p_component_name, const Dictionary &p_data) {
-	add_component_by_id(entity_id, ECS::get_component_id(p_component_name), p_data);
+void WorldECS::add_component_by_name(uint32_t entity_id, const StringName &p_component_name, const Dictionary &p_data) {
+	add_component(entity_id, ECS::get_component_id(p_component_name), p_data);
 }
 
-void WorldECS::add_component_by_id(uint32_t entity_id, uint32_t p_component_id, const Dictionary &p_data) {
+void WorldECS::add_component(uint32_t entity_id, uint32_t p_component_id, const Dictionary &p_data) {
 	CRASH_COND_MSG(world == nullptr, "The world is never nullptr.");
 	ERR_FAIL_COND_MSG(ECS::verify_component_id(p_component_id) == false, "The passed component is not valid.");
 	world->add_component(entity_id, p_component_id, p_data);
 }
 
-void WorldECS::remove_component(uint32_t entity_id, const StringName &p_component_name) {
-	remove_component_by_id(entity_id, ECS::get_component_id(p_component_name));
+void WorldECS::remove_component_by_name(uint32_t entity_id, const StringName &p_component_name) {
+	remove_component(entity_id, ECS::get_component_id(p_component_name));
 }
 
-void WorldECS::remove_component_by_id(uint32_t entity_id, uint32_t p_component_id) {
+void WorldECS::remove_component(uint32_t entity_id, uint32_t p_component_id) {
 	CRASH_COND_MSG(world == nullptr, "The world is never nullptr.");
 	ERR_FAIL_COND_MSG(ECS::verify_component_id(p_component_id) == false, "The passed component is not valid.");
 	world->remove_component(entity_id, p_component_id);
 }
 
-Object *WorldECS::get_entity_component(uint32_t entity_id, const StringName &p_component_name) {
-	return get_entity_component_by_id(entity_id, ECS::get_component_id(p_component_name));
+Object *WorldECS::get_entity_component_by_name(uint32_t entity_id, const StringName &p_component_name) {
+	return get_entity_component(entity_id, ECS::get_component_id(p_component_name));
 }
 
-Object *WorldECS::get_entity_component_by_id(uint32_t entity_id, uint32_t p_component_id) {
+Object *WorldECS::get_entity_component(uint32_t entity_id, uint32_t p_component_id) {
 	component_accessor.__target = nullptr;
 
-	if (has_entity_component_by_id(entity_id, p_component_id)) {
+	if (has_entity_component(entity_id, p_component_id)) {
 		component_accessor.__target = world->get_storage(p_component_id)->get_ptr(entity_id);
 		component_accessor.__mut = true;
 	}
@@ -451,11 +451,11 @@ Object *WorldECS::get_entity_component_by_id(uint32_t entity_id, uint32_t p_comp
 	return &component_accessor;
 }
 
-bool WorldECS::has_entity_component(uint32_t entity_id, const StringName &p_component_name) {
-	return has_entity_component_by_id(entity_id, ECS::get_component_id(p_component_name));
+bool WorldECS::has_entity_component_by_name(uint32_t entity_id, const StringName &p_component_name) {
+	return has_entity_component(entity_id, ECS::get_component_id(p_component_name));
 }
 
-bool WorldECS::has_entity_component_by_id(uint32_t entity_id, uint32_t p_component_id) {
+bool WorldECS::has_entity_component(uint32_t entity_id, uint32_t p_component_id) {
 	CRASH_COND_MSG(world == nullptr, "The world is never nullptr.");
 	ERR_FAIL_COND_V_MSG(ECS::verify_component_id(p_component_id) == false, &component_accessor, "The passed component_name is not valid.");
 	if (world->get_storage(p_component_id) == nullptr) {
@@ -464,11 +464,11 @@ bool WorldECS::has_entity_component_by_id(uint32_t entity_id, uint32_t p_compone
 	return world->get_storage(p_component_id)->has(entity_id);
 }
 
-Object *WorldECS::get_databag(const StringName &p_databag_name) {
-	return get_databag_by_id(ECS::get_databag_id(p_databag_name));
+Object *WorldECS::get_databag_by_name(const StringName &p_databag_name) {
+	return get_databag(ECS::get_databag_id(p_databag_name));
 }
 
-Object *WorldECS::get_databag_by_id(uint32_t p_databag_id) {
+Object *WorldECS::get_databag(uint32_t p_databag_id) {
 	databag_accessor.__target = nullptr;
 
 	CRASH_COND_MSG(world == nullptr, "The world is never nullptr.");

--- a/godot/nodes/ecs_world.h
+++ b/godot/nodes/ecs_world.h
@@ -142,24 +142,24 @@ public:
 	/// Creates an entity coping the components from the given `Entity`.
 	uint32_t create_entity_from_prefab(Object *p_entity);
 
-	void add_component(uint32_t entity_id, const StringName &p_component_name, const Dictionary &p_data);
-	void add_component_by_id(uint32_t entity_id, uint32_t p_component_id, const Dictionary &p_data);
+	void add_component_by_name(uint32_t entity_id, const StringName &p_component_name, const Dictionary &p_data);
+	void add_component(uint32_t entity_id, uint32_t p_component_id, const Dictionary &p_data);
 
-	void remove_component(uint32_t entity_id, const StringName &p_component_name);
-	void remove_component_by_id(uint32_t entity_id, uint32_t p_component_id);
+	void remove_component_by_name(uint32_t entity_id, const StringName &p_component_name);
+	void remove_component(uint32_t entity_id, uint32_t p_component_id);
 
 	/// Returns the component of the entity or null if not assigned.
 	/// The returned object lifetime is short, never store it.
-	Object *get_entity_component(uint32_t entity_id, const StringName &p_component_name);
-	Object *get_entity_component_by_id(uint32_t entity_id, uint32_t p_component_id);
+	Object *get_entity_component_by_name(uint32_t entity_id, const StringName &p_component_name);
+	Object *get_entity_component(uint32_t entity_id, uint32_t p_component_id);
 
-	bool has_entity_component(uint32_t entity_id, const StringName &p_component_name);
-	bool has_entity_component_by_id(uint32_t entity_id, uint32_t p_component_id);
+	bool has_entity_component_by_name(uint32_t entity_id, const StringName &p_component_name);
+	bool has_entity_component(uint32_t entity_id, uint32_t p_component_id);
 
 	/// Returns the databag or null if not present in the world.
 	/// The returned object lifetime is short, never store it.
-	Object *get_databag(const StringName &p_databag_name);
-	Object *get_databag_by_id(uint32_t p_databag_id);
+	Object *get_databag_by_name(const StringName &p_databag_name);
+	Object *get_databag(uint32_t p_databag_id);
 
 private:
 	void active_world();

--- a/godot/nodes/ecs_world.h
+++ b/godot/nodes/ecs_world.h
@@ -153,6 +153,9 @@ public:
 	Object *get_entity_component(uint32_t entity_id, const StringName &p_component_name);
 	Object *get_entity_component_by_id(uint32_t entity_id, uint32_t p_component_id);
 
+	bool has_entity_component(uint32_t entity_id, const StringName &p_component_name);
+	bool has_entity_component_by_id(uint32_t entity_id, uint32_t p_component_id);
+
 	/// Returns the databag or null if not present in the world.
 	/// The returned object lifetime is short, never store it.
 	Object *get_databag(const StringName &p_databag_name);

--- a/tests/test_ecs_world.h
+++ b/tests/test_ecs_world.h
@@ -209,7 +209,7 @@ TEST_CASE("[Modules][ECS] Test WorldECS runtime API create entity from prefab.")
 
 	// Make sure the component is created
 
-	Object *comp = world.get_entity_component(
+	Object *comp = world.get_entity_component_by_name(
 			entity_id,
 			"TransformComponent");
 
@@ -224,7 +224,7 @@ TEST_CASE("[Modules][ECS] Test WorldECS runtime API create entity from prefab.")
 TEST_CASE("[Modules][ECS] Test WorldECS runtime API fetch databags.") {
 	WorldECS world;
 
-	Object *world_res_raw = world.get_databag("World");
+	Object *world_res_raw = world.get_databag_by_name("World");
 
 	CHECK(world_res_raw != nullptr);
 


### PR DESCRIPTION
- Added `has_entity_component` to WorldECS.
- Exposed `Component` ID and `Databag` ID to scripting.
When a new component or a new databag is registered, a new constant on
the ECS singleton is added. In this way it's possible to access components
ID much easily without the need to use the string name, which is slow.
This also works for components registered via Scripts. You can access
them with the syntax: ECS.component_name_gd.
Example syntax:
```gdscript
ECS.get_active_world().has_entity_component(entity_id, ECS.TransformComponent)
```
- Converted the APIs to use constants instead of strings.
