### PR TITLE
Fixed crash when the editor closes.

### DIFF
--- a/components/component.h
+++ b/components/component.h
@@ -21,6 +21,16 @@ public:                                                                       \
 																			  \
 	ECS_PROPERTY_MAPPER(m_class)                                              \
 	ECS_METHOD_MAPPER()                                                       \
+																			  \
+	static void __static_destructor() {                                       \
+		property_map.reset();                                                 \
+		properties.reset();                                                   \
+		setters.reset();                                                      \
+		getters.reset();                                                      \
+		methods_map.reset();                                                  \
+		methods.reset();                                                      \
+	}                                                                         \
+																			  \
 private:
 
 #define COMPONENT(m_class, m_storage_class)                            \

--- a/databags/databag.h
+++ b/databags/databag.h
@@ -38,6 +38,16 @@ public:                                                                   \
 																		  \
 	ECS_PROPERTY_MAPPER(m_class)                                          \
 	ECS_METHOD_MAPPER()                                                   \
+																		  \
+	static void __static_destructor() {                                   \
+		property_map.reset();                                             \
+		properties.reset();                                               \
+		setters.reset();                                                  \
+		getters.reset();                                                  \
+		methods_map.reset();                                              \
+		methods.reset();                                                  \
+	}                                                                     \
+																		  \
 private:
 
 class Databag : public ECSClass {

--- a/ecs.cpp
+++ b/ecs.cpp
@@ -11,6 +11,7 @@
 #include "world/world.h"
 
 ECS *ECS::singleton = nullptr;
+LocalVector<func_notify_static_destructor> ECS::notify_static_destructor;
 LocalVector<StringName> ECS::components;
 LocalVector<ComponentInfo> ECS::components_info;
 LocalVector<StringName> ECS::databags;
@@ -35,6 +36,25 @@ void ECS::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_ECS_WORLD_UNLOADED)
 	BIND_CONSTANT(NOTIFICATION_ECS_WORDL_READY)
 	BIND_CONSTANT(NOTIFICATION_ECS_ENTITY_CREATED)
+}
+
+void ECS::__static_destructor() {
+	// Call static destructors.
+	for (uint32_t i = 0; i < notify_static_destructor.size(); i += 1) {
+		notify_static_destructor[i]();
+	}
+
+	// Clear the components static data.
+	components.reset();
+	components_info.reset();
+
+	// Clear the databags static data.
+	databags.reset();
+	databags_info.reset();
+
+	// Clear the systems static data.
+	systems.reset();
+	systems_info.reset();
 }
 
 ECS::ECS() :

--- a/godot/databags/input_databag.cpp
+++ b/godot/databags/input_databag.cpp
@@ -1,0 +1,13 @@
+#include "input_databag.h"
+
+InputDatabag::InputDatabag() {
+	input = Input::get_singleton();
+}
+
+Input *InputDatabag::get() {
+	return input;
+}
+
+const Input *InputDatabag::get() const {
+	return input;
+}

--- a/godot/databags/input_databag.h
+++ b/godot/databags/input_databag.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "../../databags/databag.h"
+#include "core/input/input.h"
+
+class Input;
+
+class InputDatabag : public godex::Databag {
+	DATABAG(InputDatabag)
+
+	Input *input;
+
+public:
+	InputDatabag();
+
+	Input *get();
+	const Input *get() const;
+};

--- a/godot/nodes/ecs_utilities.cpp
+++ b/godot/nodes/ecs_utilities.cpp
@@ -202,6 +202,13 @@ LocalVector<Ref<Component>> ScriptECS::components;
 LocalVector<StringName> ScriptECS::system_names;
 LocalVector<Ref<System>> ScriptECS::systems;
 
+void ScriptECS::__static_destructor() {
+	component_names.reset();
+	components.reset();
+	system_names.reset();
+	systems.reset();
+}
+
 void ScriptECS::load_components() {
 	if (component_loaded) {
 		return;

--- a/godot/nodes/ecs_utilities.h
+++ b/godot/nodes/ecs_utilities.h
@@ -89,6 +89,9 @@ class ScriptECS {
 	static LocalVector<Ref<System>> systems;
 
 public:
+	/// Clear the internal memory before the complete shutdown.
+	static void __static_destructor();
+
 	/// Loads components.
 	static void load_components();
 

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -5,15 +5,13 @@
 #include "core/object/message_queue.h"
 #include "ecs.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
-#include "iterators/dynamic_query.h"
-#include "systems/dynamic_system.h"
-
 #include "godot/components/child.h"
 #include "godot/components/disabled.h"
 #include "godot/components/mesh_component.h"
 #include "godot/components/physics/shape_3d_component.h"
 #include "godot/components/transform_component.h"
 #include "godot/databags/godot_engine_databags.h"
+#include "godot/databags/input_databag.h"
 #include "godot/databags/visual_servers_databags.h"
 #include "godot/editor_plugins/components_gizmo_3d.h"
 #include "godot/editor_plugins/editor_world_ecs.h"
@@ -23,6 +21,8 @@
 #include "godot/nodes/entity.h"
 #include "godot/systems/mesh_updater_system.h"
 #include "godot/systems/physics_process_system.h"
+#include "iterators/dynamic_query.h"
+#include "systems/dynamic_system.h"
 
 // TODO improve this workflow once the new pipeline is integrated.
 class REP : public Object {
@@ -100,6 +100,9 @@ void register_godex_types() {
 	// Physics
 	ECS::register_databag<Physics3D>();
 
+	// Input
+	ECS::register_databag<InputDatabag>();
+
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Register engine systems
 	// Engine
 	ECS::register_system(call_physics_process, "CallPhysicsProcess", "Updates the Godot Nodes (2D/3D) transform and fetches the events from the physics engine.");
@@ -118,6 +121,15 @@ void register_godex_types() {
 }
 
 void unregister_godex_types() {
+	// Clear dynamic system static memory.
+	godex::__dynamic_system_info_static_destructor();
+	godex::DynamicSystemInfo::for_each_name = StringName();
+
+	// Clear ScriptECS static memory.
+	ScriptECS::__static_destructor();
+
+	// Clear ECS static memory.
+	ECS::__static_destructor();
 	ECS *ecs = ECS::get_singleton();
 	ECS::__set_singleton(nullptr);
 	memdelete(ecs);

--- a/systems/dynamic_system.cpp
+++ b/systems/dynamic_system.cpp
@@ -7,6 +7,13 @@
 // compile time system.
 #include "dynamic_system.gen.h"
 
+void godex::__dynamic_system_info_static_destructor() {
+	for (uint32_t i = 0; i < DYNAMIC_SYSTEMS_MAX; i += 1) {
+		dynamic_info[i].reset();
+	}
+	registered_dynamic_system_count = 0;
+}
+
 godex::DynamicSystemInfo::DynamicSystemInfo() {}
 
 void godex::DynamicSystemInfo::set_system_id(uint32_t p_id) {
@@ -138,6 +145,25 @@ bool godex::DynamicSystemInfo::is_system_dispatcher() const {
 
 EntityID godex::DynamicSystemInfo::get_current_entity_id() const {
 	return query.get_current_entity_id();
+}
+
+void godex::DynamicSystemInfo::reset() {
+	target_script = nullptr;
+	compiled = false;
+	gdscript_function = nullptr;
+	system_id = UINT32_MAX;
+	databag_element_map.reset();
+	storage_element_map.reset();
+	query_element_map.reset();
+	databags.reset();
+	storages.reset();
+	query.reset();
+	access.reset();
+	access_ptr.reset();
+	databag_accessors.reset();
+	storage_accessors.reset();
+	sub_pipeline_execute = nullptr;
+	target_sub_pipeline = nullptr;
 }
 
 StringName godex::DynamicSystemInfo::for_each_name;

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -22,6 +22,7 @@ typedef void (*func_system_execute_pipeline)(World *p_world, Pipeline *p_pipelin
 uint32_t register_dynamic_system();
 func_get_system_exe_info get_func_dynamic_system_exec_info(uint32_t p_dynamic_system_id);
 DynamicSystemInfo *get_dynamic_system_info(uint32_t p_dynamic_system_id);
+void __dynamic_system_info_static_destructor();
 
 /// `DynamicSystemInfo` is a class used to compose a system at runtime.
 /// It's able to execute script systems and sub pipeline systems, in both case
@@ -88,6 +89,8 @@ public:
 	bool is_system_dispatcher() const;
 
 	EntityID get_current_entity_id() const;
+
+	void reset();
 
 public:
 	static StringName for_each_name;


### PR DESCRIPTION
The crash was due to some static `StringName`. The `StringName` was cleared
at the end of the application, when the centralized DB didn't exist
anymore.
This was causing some trouble, so I've added a mechanism that clears the
static memory when the godex module un `unregistered`.

Also added `InputDatabag`