### PR TITLE
Improved Query syntax and optimized fetch.

### DIFF
--- a/godot/systems/mesh_updater_system.cpp
+++ b/godot/systems/mesh_updater_system.cpp
@@ -15,10 +15,8 @@ void scenario_manager_system(
 	if (p_scenario->scenario != main_scenario) {
 		p_scenario->scenario = main_scenario;
 
-		while (p_query.is_done() == false) {
-			auto [mesh_comp] = p_query.get();
+		for (auto [mesh_comp] : p_query) {
 			rs->get_rs()->instance_set_scenario(mesh_comp->instance, p_scenario->scenario);
-			p_query.next();
 		}
 	}
 }
@@ -30,9 +28,7 @@ void mesh_updater_system(
 	ERR_FAIL_COND_MSG(p_scenario == nullptr, "The `RenderingScenarioDatabag` `Databag` is not part of this world. Add it please.");
 	ERR_FAIL_COND_MSG(rs == nullptr, "The `RenderingServerDatabag` `Databag` is not part of this world. Add it please.");
 
-	while (p_query.is_done() == false) {
-		MeshComponent *mesh_comp = std::get<Batch<MeshComponent>>(p_query.get());
-
+	for (auto [mesh_comp] : p_query) {
 		if (mesh_comp->instance == RID()) {
 			// Instance the Mesh.
 			RID instance = rs->get_rs()->instance_create();
@@ -53,8 +49,6 @@ void mesh_updater_system(
 		rs->get_rs()->instance_set_visible(mesh_comp->instance, mesh_comp->visible);
 		rs->get_rs()->instance_set_layer_mask(mesh_comp->instance, mesh_comp->layers);
 		// TODO add material override, once the `Changed<>` filter is integrated.
-
-		p_query.next();
 	}
 }
 
@@ -63,13 +57,9 @@ void mesh_transform_updater_system(
 		Query<const MeshComponent, Changed<const TransformComponent>> &p_query) {
 	ERR_FAIL_COND_MSG(rs == nullptr, "The `RenderingServerDatabag` `Databag` is not part of this world. Add it please.");
 
-	while (p_query.is_done() == false) {
-		auto [mesh, transf] = p_query.get(Space::GLOBAL);
-
+	for (auto [mesh, transf] : p_query.space(Space::GLOBAL)) {
 		if (mesh->instance != RID()) {
 			rs->get_rs()->instance_set_transform(mesh->instance, transf->transform);
 		}
-
-		p_query.next();
 	}
 }

--- a/storage/entity_list.cpp
+++ b/storage/entity_list.cpp
@@ -80,7 +80,7 @@ bool EntityList::is_empty() const {
 	return dense_list.size() == 0;
 }
 
-bool EntityList::size() const {
+uint32_t EntityList::size() const {
 	return dense_list.size();
 }
 
@@ -99,6 +99,6 @@ void EntityList::reset() {
 	dense_list.reset();
 }
 
-const LocalVector<EntityID> &EntityList::get_entities() const {
-	return dense_list;
+const EntityID *EntityList::get_entities_ptr() const {
+	return dense_list.ptr();
 }

--- a/storage/entity_list.h
+++ b/storage/entity_list.h
@@ -44,7 +44,7 @@ public:
 
 	bool is_empty() const;
 
-	bool size() const;
+	uint32_t size() const;
 
 	/// Clear the memory, but don't deallocate it so next frame it will run
 	/// faster.
@@ -53,5 +53,5 @@ public:
 	/// Release the memory completely.
 	void reset();
 
-	const LocalVector<EntityID> &get_entities() const;
+	const EntityID *get_entities_ptr() const;
 };

--- a/storage/hierarchical_storage.h
+++ b/storage/hierarchical_storage.h
@@ -18,7 +18,7 @@ public:
 
 class Hierarchy : public Storage<Child> {
 	DenseVector<Child> storage;
-	EntityList changed;
+	EntityList hierarchy_changed;
 	LocalVector<HierarchicalStorageBase *> sub_storages;
 
 public:
@@ -29,7 +29,7 @@ public:
 	}
 
 	const EntityList &get_changed() const {
-		return changed;
+		return hierarchy_changed;
 	}
 
 	virtual void on_system_release() override {
@@ -40,7 +40,7 @@ public:
 		for (uint32_t i = 0; i < sub_storages.size(); i += 1) {
 			sub_storages[i]->flush_hierarchy_changes();
 		}
-		changed.clear();
+		hierarchy_changed.clear();
 	}
 
 	virtual String get_type_name() const override {
@@ -69,7 +69,7 @@ public:
 			storage.remove(p_entity);
 
 			// 4. Mark this as changed.
-			changed.insert(p_entity);
+			hierarchy_changed.insert(p_entity);
 		}
 	}
 
@@ -119,14 +119,14 @@ public:
 			child.next = EntityID();
 		}
 
-		changed.insert(p_entity);
+		hierarchy_changed.insert(p_entity);
 
 		// Update the parent if any.
 		if (child.parent.is_null() == false) {
 			if (has(child.parent) == false) {
 				// Parent is always root when added in this way.
 				storage.insert(child.parent, Child());
-				changed.insert(child.parent);
+				hierarchy_changed.insert(child.parent);
 			}
 
 			Child &parent = storage.get(child.parent);

--- a/storage/storage.h
+++ b/storage/storage.h
@@ -10,8 +10,10 @@ enum Space {
 };
 
 struct EntitiesBuffer {
-	const uint32_t count;
+	uint32_t count;
 	const EntityID *entities;
+	EntitiesBuffer(uint32_t c, const EntityID *e) :
+			count(c), entities(e) {}
 };
 
 /// Never override this directly. Always override the `Storage`.
@@ -102,7 +104,7 @@ public:
 	}
 
 	EntitiesBuffer get_changed_entities() const {
-		return { changed.size(), changed.get_entities().ptr() };
+		return EntitiesBuffer(changed.size(), changed.get_entities_ptr());
 	}
 
 public:


### PR DESCRIPTION
**Query optimization:**
The static `Query` fetch is optimized, now it iterates only on a given range
of Entities. That `Entities` are the more likely to fulfil the query
requirements, so worth the check.
For example, if you specify a query like this:
`Query<Changed<TransformComponent>>` the `Entities` checked are just the
changed one for that storage, this mean that the fetch is blazing fast.
If you have a more complex query, like this: `Query<TransformComponent, Enemy>`
the query iterates on the storages that have less components; in this
case the `Enemy` storage drives the iteration so again the processing is
super fast.

**Query syntax improvement:**
The `Query` syntax is now improved; thanks to the iterator usage, is now
possible to process the query like this:
```cpp
for(auto [transform, enemy] : query){
	// ...
}
```
The random access is also simplified:
```cpp
if( query.has(1) ){
	auto [transform, enemy] = query[1];
}
```