### PR TITLE
Improved ECS editor

### DIFF
--- a/godot/editor_plugins/editor_world_ecs.cpp
+++ b/godot/editor_plugins/editor_world_ecs.cpp
@@ -258,15 +258,14 @@ EditorWorldECS::EditorWorldECS(EditorNode *p_editor) :
 		//create_comp_btn->connect("pressed", callable_mp(this, &EditorWorldECS::create_sys_show)); // TODO
 		menu_wrapper->add_child(create_comp_btn);
 
+		node_name_lbl = memnew(Label);
+		menu_wrapper->add_child(node_name_lbl);
+
 		// ~~ Sub menu world ECS ~~
 		{
-			HBoxContainer *world_ecs_sub_menu_wrap = memnew(HBoxContainer);
+			world_ecs_sub_menu_wrap = memnew(HBoxContainer);
 			world_ecs_sub_menu_wrap->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
 			menu_wrapper->add_child(world_ecs_sub_menu_wrap);
-
-			node_name_lbl = memnew(Label);
-			node_name_lbl->add_theme_color_override("font_color", Color(0.0, 0.5, 1.0));
-			world_ecs_sub_menu_wrap->add_child(node_name_lbl);
 
 			pipeline_menu = memnew(OptionButton);
 			pipeline_menu->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
@@ -309,7 +308,7 @@ EditorWorldECS::EditorWorldECS(EditorNode *p_editor) :
 
 	// ~~ Workspace ~~
 
-	HBoxContainer *workspace_container_hb = memnew(HBoxContainer);
+	workspace_container_hb = memnew(HBoxContainer);
 	workspace_container_hb->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
 	workspace_container_hb->set_v_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
 	main_vb->add_child(workspace_container_hb);
@@ -481,16 +480,14 @@ void EditorWorldECS::show_editor() {
 		}
 	}
 
-	if (world_ecs != nullptr) {
-		show();
-	} else {
-		hide();
-	}
 	add_sys_hide();
 	create_sys_hide();
+	pipeline_window_rename->set_visible(false);
 	pipeline_window_confirm_remove->set_visible(false);
 
-	pipeline_list_update();
+	// Refresh world ECS show hide.
+	set_world_ecs(world_ecs);
+	show();
 }
 
 void EditorWorldECS::hide_editor() {
@@ -502,9 +499,13 @@ void EditorWorldECS::hide_editor() {
 void EditorWorldECS::set_world_ecs(WorldECS *p_world) {
 	if (world_ecs != nullptr) {
 		world_ecs->remove_change_receptor(this);
-		node_name_lbl->set_text("");
-		set_pipeline(Ref<PipelineECS>());
 	}
+
+	node_name_lbl->set_text("No world ECS selected.");
+	node_name_lbl->add_theme_color_override("font_color", Color(0.7, 0.7, 0.7));
+	set_pipeline(Ref<PipelineECS>());
+	world_ecs_sub_menu_wrap->hide();
+	workspace_container_hb->hide();
 
 	world_ecs = p_world;
 	pipeline_panel_clear();
@@ -512,7 +513,9 @@ void EditorWorldECS::set_world_ecs(WorldECS *p_world) {
 	if (world_ecs != nullptr) {
 		world_ecs->add_change_receptor(this);
 		node_name_lbl->set_text(world_ecs->get_name());
-		show();
+		node_name_lbl->add_theme_color_override("font_color", Color(0.0, 0.5, 1.0));
+		world_ecs_sub_menu_wrap->show();
+		workspace_container_hb->show();
 	}
 
 	pipeline_list_update();

--- a/godot/editor_plugins/editor_world_ecs.cpp
+++ b/godot/editor_plugins/editor_world_ecs.cpp
@@ -211,14 +211,14 @@ EditorWorldECS::EditorWorldECS(EditorNode *p_editor) :
 	set_offset(SIDE_RIGHT, 0.0);
 	set_offset(SIDE_BOTTOM, 0.0);
 
-	HBoxContainer *main_hb = memnew(HBoxContainer);
-	main_hb->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
-	main_hb->set_v_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
-	main_hb->set_anchor(SIDE_LEFT, 0.0);
-	main_hb->set_anchor(SIDE_TOP, 0.0);
-	main_hb->set_anchor(SIDE_RIGHT, 1.0);
-	main_hb->set_anchor(SIDE_BOTTOM, 1.0);
-	add_child(main_hb);
+	VBoxContainer *main_vb = memnew(VBoxContainer);
+	main_vb->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+	main_vb->set_v_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+	main_vb->set_anchor(SIDE_LEFT, 0.0);
+	main_vb->set_anchor(SIDE_TOP, 0.0);
+	main_vb->set_anchor(SIDE_RIGHT, 1.0);
+	main_vb->set_anchor(SIDE_BOTTOM, 1.0);
+	add_child(main_vb);
 
 	DrawLayer *draw_layer = memnew(DrawLayer);
 	draw_layer->editor = this;
@@ -234,78 +234,101 @@ EditorWorldECS::EditorWorldECS(EditorNode *p_editor) :
 	draw_layer->set_offset(SIDE_BOTTOM, 0.0);
 	add_child(draw_layer);
 
-	// ~~ Left Panel ~~
+	// ~~ Main menu ~~
 	{
-		VBoxContainer *main_container = memnew(VBoxContainer);
-		main_container->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
-		main_container->set_v_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
-		main_hb->add_child(main_container);
+		HBoxContainer *menu_wrapper = memnew(HBoxContainer);
+		menu_wrapper->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+		main_vb->add_child(menu_wrapper);
 
-		// ~~ Action box ~~
+		Button *create_sys_btn = memnew(Button);
+		create_sys_btn->set_text(TTR("New system"));
+		create_sys_btn->set_icon(editor->get_theme_base()->get_theme_icon("ScriptCreate", "EditorIcons"));
+		create_sys_btn->set_flat(true);
+		create_sys_btn->set_h_size_flags(0.0);
+		create_sys_btn->set_v_size_flags(0.0);
+		create_sys_btn->connect("pressed", callable_mp(this, &EditorWorldECS::create_sys_show));
+		menu_wrapper->add_child(create_sys_btn);
+
+		Button *create_comp_btn = memnew(Button);
+		create_comp_btn->set_text(TTR("Components"));
+		create_comp_btn->set_icon(editor->get_theme_base()->get_theme_icon("Load", "EditorIcons"));
+		create_comp_btn->set_flat(true);
+		create_comp_btn->set_h_size_flags(0.0);
+		create_comp_btn->set_v_size_flags(0.0);
+		//create_comp_btn->connect("pressed", callable_mp(this, &EditorWorldECS::create_sys_show)); // TODO
+		menu_wrapper->add_child(create_comp_btn);
+
+		// ~~ Sub menu world ECS ~~
 		{
-			HBoxContainer *hori_box = memnew(HBoxContainer);
-			hori_box->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
-			hori_box->set_v_size_flags(0);
-			main_container->add_child(hori_box);
+			HBoxContainer *world_ecs_sub_menu_wrap = memnew(HBoxContainer);
+			world_ecs_sub_menu_wrap->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+			menu_wrapper->add_child(world_ecs_sub_menu_wrap);
 
 			node_name_lbl = memnew(Label);
 			node_name_lbl->add_theme_color_override("font_color", Color(0.0, 0.5, 1.0));
-			hori_box->add_child(node_name_lbl);
+			world_ecs_sub_menu_wrap->add_child(node_name_lbl);
 
 			pipeline_menu = memnew(OptionButton);
 			pipeline_menu->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
 			pipeline_menu->connect("item_selected", callable_mp(this, &EditorWorldECS::pipeline_on_menu_select));
-			hori_box->add_child(pipeline_menu);
+			world_ecs_sub_menu_wrap->add_child(pipeline_menu);
 
 			Button *new_pipeline_btn = memnew(Button);
 			new_pipeline_btn->set_h_size_flags(0);
 			new_pipeline_btn->set_icon(editor->get_theme_base()->get_theme_icon("New", "EditorIcons"));
+			new_pipeline_btn->set_flat(true);
 			new_pipeline_btn->set_text(TTR("Add pipeline"));
 			new_pipeline_btn->connect("pressed", callable_mp(this, &EditorWorldECS::pipeline_add));
-			hori_box->add_child(new_pipeline_btn);
+			world_ecs_sub_menu_wrap->add_child(new_pipeline_btn);
 
+			Button *rename_pipeline_btn = memnew(Button);
+			rename_pipeline_btn->set_text(TTR("Rename"));
+			rename_pipeline_btn->set_h_size_flags(0);
+			rename_pipeline_btn->set_icon(editor->get_theme_base()->get_theme_icon("Edit", "EditorIcons"));
+			rename_pipeline_btn->set_flat(true);
+			rename_pipeline_btn->connect("pressed", callable_mp(this, &EditorWorldECS::pipeline_rename_show_window));
+			world_ecs_sub_menu_wrap->add_child(rename_pipeline_btn);
+
+			pipeline_window_confirm_remove = memnew(ConfirmationDialog);
 			Button *remove_pipeline_btn = memnew(Button);
 			remove_pipeline_btn->set_h_size_flags(0);
 			remove_pipeline_btn->set_icon(editor->get_theme_base()->get_theme_icon("Remove", "EditorIcons"));
+			remove_pipeline_btn->set_flat(true);
 			remove_pipeline_btn->connect("pressed", callable_mp(this, &EditorWorldECS::pipeline_remove_show_confirmation));
-			hori_box->add_child(remove_pipeline_btn);
+			world_ecs_sub_menu_wrap->add_child(remove_pipeline_btn);
 
-			pipeline_confirm_remove = memnew(ConfirmationDialog);
-			pipeline_confirm_remove->set_min_size(Size2i(200, 80));
-			pipeline_confirm_remove->set_title(TTR("Confirm removal"));
-			pipeline_confirm_remove->get_label()->set_text(TTR("Do you want to drop the selected pipeline?"));
-			pipeline_confirm_remove->get_ok_button()->set_text(TTR("Confirm"));
-			pipeline_confirm_remove->connect("confirmed", callable_mp(this, &EditorWorldECS::pipeline_remove));
-			add_child(pipeline_confirm_remove);
+			pipeline_window_confirm_remove = memnew(ConfirmationDialog);
+			pipeline_window_confirm_remove->set_min_size(Size2i(200, 80));
+			pipeline_window_confirm_remove->set_title(TTR("Confirm removal"));
+			pipeline_window_confirm_remove->get_label()->set_text(TTR("Do you want to drop the selected pipeline?"));
+			pipeline_window_confirm_remove->get_ok_button()->set_text(TTR("Confirm"));
+			pipeline_window_confirm_remove->connect("confirmed", callable_mp(this, &EditorWorldECS::pipeline_remove));
+			add_child(pipeline_window_confirm_remove);
 		}
 	}
 
-	VSeparator *separator = memnew(VSeparator);
-	main_hb->add_child(separator);
+	// ~~ Workspace ~~
+
+	HBoxContainer *workspace_container_hb = memnew(HBoxContainer);
+	workspace_container_hb->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+	workspace_container_hb->set_v_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+	main_vb->add_child(workspace_container_hb);
+
+	// ~~ Left Panel ~~
+	{
+		// TODO remove
+		VBoxContainer *main_container = memnew(VBoxContainer);
+		main_container->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+		main_container->set_v_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+		workspace_container_hb->add_child(main_container);
+	}
 
 	// ~~ Right Panel ~~
 	{
 		VBoxContainer *main_container = memnew(VBoxContainer);
 		main_container->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
 		main_container->set_v_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
-		main_hb->add_child(main_container);
-
-		HBoxContainer *title_container = memnew(HBoxContainer);
-		title_container->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
-		title_container->set_v_size_flags(0);
-		main_container->add_child(title_container);
-
-		Label *title = memnew(Label);
-		title->set_text(TTR("Pipeline"));
-		title->set_h_size_flags(0);
-		title->set_v_size_flags(SIZE_FILL | SIZE_EXPAND);
-		title_container->add_child(title);
-
-		pip_name_ledit = memnew(LineEdit);
-		pip_name_ledit->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
-		pip_name_ledit->set_v_size_flags(0);
-		pip_name_ledit->connect("text_changed", callable_mp(this, &EditorWorldECS::pipeline_change_name));
-		title_container->add_child(pip_name_ledit);
+		workspace_container_hb->add_child(main_container);
 
 		Panel *panel = memnew(Panel);
 		panel->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
@@ -343,13 +366,31 @@ EditorWorldECS::EditorWorldECS(EditorNode *p_editor) :
 		show_btn_add_sys->set_v_size_flags(0);
 		show_btn_add_sys->connect("pressed", callable_mp(this, &EditorWorldECS::add_sys_show));
 		button_container->add_child(show_btn_add_sys);
+	}
 
-		Button *create_sys_btn = memnew(Button);
-		create_sys_btn->set_icon(editor->get_theme_base()->get_theme_icon("New", "EditorIcons"));
-		create_sys_btn->set_h_size_flags(0.0);
-		create_sys_btn->set_v_size_flags(0.0);
-		create_sys_btn->connect("pressed", callable_mp(this, &EditorWorldECS::create_sys_show));
-		button_container->add_child(create_sys_btn);
+	// ~~ Rename pipeline window ~~
+	{
+		pipeline_window_rename = memnew(AcceptDialog);
+		pipeline_window_rename->set_min_size(Size2i(500, 180));
+		pipeline_window_rename->set_title(TTR("Rename pipeline"));
+		pipeline_window_rename->set_hide_on_ok(true);
+		pipeline_window_rename->get_ok_button()->set_text(TTR("Ok"));
+		pipeline_window_rename->connect("confirmed", callable_mp(this, &EditorWorldECS::add_script_do));
+		add_child(pipeline_window_rename);
+
+		VBoxContainer *vert_container = memnew(VBoxContainer);
+		vert_container->set_h_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+		vert_container->set_v_size_flags(SizeFlags::SIZE_FILL | SizeFlags::SIZE_EXPAND);
+		pipeline_window_rename->add_child(vert_container);
+
+		Label *lbl = memnew(Label);
+		lbl->set_text("Pipeline name");
+		vert_container->add_child(lbl);
+
+		pipeline_name_ledit = memnew(LineEdit);
+		pipeline_name_ledit->set_placeholder(TTR("Pipeline name"));
+		pipeline_name_ledit->connect("text_changed", callable_mp(this, &EditorWorldECS::pipeline_change_name));
+		vert_container->add_child(pipeline_name_ledit);
 	}
 
 	// ~~ Add system window ~~
@@ -447,7 +488,7 @@ void EditorWorldECS::show_editor() {
 	}
 	add_sys_hide();
 	create_sys_hide();
-	pipeline_confirm_remove->set_visible(false);
+	pipeline_window_confirm_remove->set_visible(false);
 
 	pipeline_list_update();
 }
@@ -550,12 +591,12 @@ void EditorWorldECS::pipeline_on_menu_select(int p_index) {
 		set_pipeline(Ref<PipelineECS>());
 	}
 	if (pipeline.is_null()) {
-		pip_name_ledit->set_text("");
+		pipeline_name_ledit->set_text("");
 	} else {
-		pip_name_ledit->set_text(pipeline->get_pipeline_name());
+		pipeline_name_ledit->set_text(pipeline->get_pipeline_name());
 	}
 	// Always position the cursor at the end.
-	pip_name_ledit->set_cursor_position(INT32_MAX);
+	pipeline_name_ledit->set_cursor_position(INT32_MAX);
 	pipeline_panel_update();
 }
 
@@ -590,10 +631,16 @@ void EditorWorldECS::pipeline_add() {
 	editor->get_undo_redo()->commit_action();
 }
 
+void EditorWorldECS::pipeline_rename_show_window() {
+	const Vector2i modal_pos = (Vector2i(get_viewport_rect().size) - pipeline_window_rename->get_size()) / 2.0;
+	pipeline_window_rename->set_position(modal_pos);
+	pipeline_window_rename->set_visible(true);
+}
+
 void EditorWorldECS::pipeline_remove_show_confirmation() {
-	const Vector2i modal_pos = (Vector2i(get_viewport_rect().size) - pipeline_confirm_remove->get_size()) / 2.0;
-	pipeline_confirm_remove->set_position(modal_pos);
-	pipeline_confirm_remove->set_visible(true);
+	const Vector2i modal_pos = (Vector2i(get_viewport_rect().size) - pipeline_window_confirm_remove->get_size()) / 2.0;
+	pipeline_window_confirm_remove->set_position(modal_pos);
+	pipeline_window_confirm_remove->set_visible(true);
 }
 
 void EditorWorldECS::pipeline_remove() {

--- a/godot/editor_plugins/editor_world_ecs.h
+++ b/godot/editor_plugins/editor_world_ecs.h
@@ -10,6 +10,7 @@ class WorldECS;
 class PipelineECS;
 class EditorWorldECS;
 class SpinBox;
+class Tree;
 
 class SystemInfoBox : public MarginContainer {
 	GDCLASS(SystemInfoBox, MarginContainer);
@@ -52,6 +53,14 @@ public:
 
 	void system_remove();
 	void dispatcher_pipeline_change(const String &p_value);
+};
+
+class ComponentElement : public HBoxContainer {
+	EditorNode *editor = nullptr;
+
+public:
+	ComponentElement(EditorNode *p_editor);
+	~ComponentElement();
 };
 
 class DrawLayer : public Control {
@@ -100,6 +109,10 @@ class EditorWorldECS : public PanelContainer {
 	LineEdit *add_script_path = nullptr;
 	Label *add_script_error_lbl = nullptr;
 
+	AcceptDialog *components_window = nullptr;
+	Tree *components_tree = nullptr;
+	LineEdit *component_name_le = nullptr;
+
 	LocalVector<SystemInfoBox *> pipeline_systems;
 
 	bool is_pipeline_panel_dirty = false;
@@ -139,6 +152,9 @@ public:
 	void create_sys_show();
 	void create_sys_hide();
 	void add_script_do();
+
+	void components_manage_show();
+	void components_manage_on_component_select();
 
 protected:
 	void _changed_callback(Object *p_changed, const char *p_prop) override;

--- a/godot/editor_plugins/editor_world_ecs.h
+++ b/godot/editor_plugins/editor_world_ecs.h
@@ -76,6 +76,9 @@ class EditorWorldECS : public PanelContainer {
 	WorldECS *world_ecs = nullptr;
 	Ref<PipelineECS> pipeline;
 
+	HBoxContainer *world_ecs_sub_menu_wrap = nullptr;
+	HBoxContainer *workspace_container_hb = nullptr;
+
 	DrawLayer *draw_layer = nullptr;
 	Label *node_name_lbl = nullptr;
 	VBoxContainer *pipeline_panel = nullptr;
@@ -160,7 +163,7 @@ public:
 	WorldECSEditorPlugin(EditorNode *p_node);
 	~WorldECSEditorPlugin();
 
-	virtual String get_name() const override { return "WorldECS"; }
+	virtual String get_name() const override { return "ECS"; }
 	virtual bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/godot/editor_plugins/editor_world_ecs.h
+++ b/godot/editor_plugins/editor_world_ecs.h
@@ -33,6 +33,7 @@ private:
 	Label *system_name_lbl = nullptr;
 	ItemList *system_data_list = nullptr;
 	LineEdit *dispatcher_pipeline_name = nullptr;
+	Button *toggle_system_data_btn = nullptr;
 
 	StringName system_name;
 	SystemMode mode = SYSTEM_INVALID;
@@ -53,14 +54,22 @@ public:
 
 	void system_remove();
 	void dispatcher_pipeline_change(const String &p_value);
+
+	void system_toggle_data();
 };
 
 class ComponentElement : public HBoxContainer {
 	EditorNode *editor = nullptr;
 
+	OptionButton *type = nullptr;
+	LineEdit *name = nullptr;
+	LineEdit *val = nullptr;
+
 public:
-	ComponentElement(EditorNode *p_editor);
+	ComponentElement(EditorNode *p_editor, const String &p_name = "", Variant p_default = false);
 	~ComponentElement();
+
+	void init_variable(const String &p_name, Variant p_default);
 };
 
 class DrawLayer : public Control {

--- a/godot/editor_plugins/editor_world_ecs.h
+++ b/godot/editor_plugins/editor_world_ecs.h
@@ -78,10 +78,13 @@ class EditorWorldECS : public PanelContainer {
 
 	DrawLayer *draw_layer = nullptr;
 	Label *node_name_lbl = nullptr;
-	LineEdit *pip_name_ledit = nullptr;
 	VBoxContainer *pipeline_panel = nullptr;
 	OptionButton *pipeline_menu = nullptr;
-	ConfirmationDialog *pipeline_confirm_remove = nullptr;
+	ConfirmationDialog *pipeline_window_confirm_remove = nullptr;
+
+	// Rename pipeline
+	AcceptDialog *pipeline_window_rename = nullptr;
+	LineEdit *pipeline_name_ledit = nullptr;
 
 	// Add system window.
 	ConfirmationDialog *add_sys_window = nullptr;
@@ -115,6 +118,7 @@ public:
 	void pipeline_list_update();
 	void pipeline_on_menu_select(int p_index);
 	void pipeline_add();
+	void pipeline_rename_show_window();
 	void pipeline_remove_show_confirmation();
 	void pipeline_remove();
 	void pipeline_panel_update();

--- a/icons/ECS.svg
+++ b/icons/ECS.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="ECS.svg"
+   id="svg8"
+   version="1.1"
+   width="16"
+   viewBox="0 0 16 16"
+   height="16">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg8"
+     inkscape:window-maximized="0"
+     inkscape:window-y="37"
+     inkscape:window-x="0"
+     inkscape:cy="9.279939"
+     inkscape:cx="8.3022431"
+     inkscape:zoom="26.589315"
+     showgrid="false"
+     id="namedview10"
+     inkscape:window-height="1041"
+     inkscape:window-width="1916"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     inkscape:document-rotation="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <sodipodi:guide
+       position="7.8979094,7.9516542"
+       orientation="0,-1"
+       id="guide842" />
+  </sodipodi:namedview>
+  <path
+     id="rect837"
+     style="fill:#fff200;fill-opacity:0.996078;stroke:none;stroke-width:5.82709"
+     d="M 7.1279649,8.515 7.1340249,3.8054707 14.99034,12.160365 H 0.98973346 L 1.0050235,8.515 Z"
+     sodipodi:nodetypes="cccccc" />
+</svg>


### PR DESCRIPTION
Fixes #15

This PR improves the ECS editor. 
- Now the button to add script Systems and Components is always visible even when the `WorldECS` is not selected.
- There is a button to renamed the Pipeline that now spawns a new Window.
- The left side menu got removed, so the systems have more space available.
- The System Data is hidden by default, but you can show it using the button at right side.
- The System remove now has and `X` icon and it's always show.
- Changed Editor name, now it's just called `ECS`
- Added new `ECS` icon.

https://user-images.githubusercontent.com/8342599/108681460-75f61780-74ef-11eb-8c62-11317bcf5fcf.mp4

In addition, I've implemented the HUD to manage the `Component`s, there you will see all the components available in the project.

![Screenshot from 2021-02-22 09-37-51](https://user-images.githubusercontent.com/8342599/108683254-aa6ad300-74f1-11eb-9b2a-a93efef3b0f6.png)


Right now it still WIP because I didn't fully implemented it. The initial idea was to create this UI to allow the user create the scripted Components. However, it's necessary for the UI to provide a way to set the default value, so it's necessary to code a specific UI for each variant type. This can potentially add a lot of work that I can skip if I keep the feature to add components via code.

If it's not worth support this feature (considering that people doesn't seems really happy about it), convert it like a window that show all the registered components.