### PR TITLE
Added SteadyStorage. Put DenseVectorStorage in its own file

### DIFF
--- a/components/component.h
+++ b/components/component.h
@@ -4,7 +4,7 @@
 
 #include "../ecs.h"
 #include "../storage/batch_storage.h"
-#include "../storage/dense_vector.h"
+#include "../storage/dense_vector_storage.h"
 #include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/templates/oa_hash_map.h"

--- a/storage/dense_vector.h
+++ b/storage/dense_vector.h
@@ -1,7 +1,5 @@
 /* Author: AndreaCatania */
-
-#ifndef DENSE_VECTOR_H
-#define DENSE_VECTOR_H
+#pragma once
 
 #include "../ecs.h"
 #include "core/templates/local_vector.h"
@@ -92,76 +90,3 @@ protected:
 		entity_to_data[p_entity] = p_index;
 	}
 };
-
-/// Dense vector storage.
-/// Has a redirection 2-way table between entities and
-/// components (vice versa), allowing to leave no gaps within the data.
-/// The the entity indices are stored sparsely.
-template <class T>
-class DenseVectorStorage : public Storage<T> {
-protected:
-	DenseVector<T> storage;
-
-public:
-	virtual String get_type_name() const override {
-		return "DenseVector[" + String(typeid(T).name()) + "]";
-	}
-
-	virtual void insert(EntityID p_entity, const T &p_data) override {
-		storage.insert(p_entity, p_data);
-		StorageBase::notify_changed(p_entity);
-	}
-
-	virtual bool has(EntityID p_entity) const override {
-		return storage.has(p_entity);
-	}
-
-	virtual Batch<const std::remove_const_t<T>> get(EntityID p_entity, Space p_mode = Space::LOCAL) const override {
-		return &storage.get(p_entity);
-	}
-
-	virtual Batch<std::remove_const_t<T>> get(EntityID p_entity, Space p_mode = Space::LOCAL) override {
-		StorageBase::notify_changed(p_entity);
-		return &storage.get(p_entity);
-	}
-
-	virtual void remove(EntityID p_entity) override {
-		storage.remove(p_entity);
-		// Make sure to remove as changed.
-		StorageBase::notify_updated(p_entity);
-	}
-
-	virtual void clear() override {
-		storage.clear();
-		StorageBase::flush_changed();
-	}
-
-	virtual EntitiesBuffer get_stored_entities() const {
-		return { storage.get_entities().size(), storage.get_entities().ptr() };
-	}
-};
-
-template <class T>
-class DynamicDenseVectorStorage : public DenseVectorStorage<T> {
-	DynamicComponentInfo *dynamic_componente_info = nullptr;
-
-public:
-	DynamicDenseVectorStorage(DynamicComponentInfo *p_info) :
-			dynamic_componente_info(p_info) {}
-
-	virtual void insert_dynamic(EntityID p_entity, const Dictionary &p_data) override {
-		T insert_data;
-
-		// Initialize with defaults.
-		insert_data.__initialize(dynamic_componente_info);
-
-		// Set the custom data if any
-		for (const Variant *key = p_data.next(); key; key = p_data.next(key)) {
-			T::set_by_name(&insert_data, StringName(*key), *p_data.getptr(*key));
-		}
-
-		this->insert(p_entity, insert_data);
-	}
-};
-
-#endif

--- a/storage/dense_vector_storage.h
+++ b/storage/dense_vector_storage.h
@@ -1,0 +1,77 @@
+/* Author: AndreaCatania */
+#pragma once
+
+#include "../ecs.h"
+#include "dense_vector.h"
+#include "storage.h"
+
+/// Dense vector storage.
+/// Has a redirection 2-way table between entities and
+/// components (vice versa), allowing to leave no gaps within the data.
+/// The the entity indices are stored sparsely.
+template <class T>
+class DenseVectorStorage : public Storage<T> {
+protected:
+	DenseVector<T> storage;
+
+public:
+	virtual String get_type_name() const override {
+		return "DenseVector[" + String(typeid(T).name()) + "]";
+	}
+
+	virtual void insert(EntityID p_entity, const T &p_data) override {
+		storage.insert(p_entity, p_data);
+		StorageBase::notify_changed(p_entity);
+	}
+
+	virtual bool has(EntityID p_entity) const override {
+		return storage.has(p_entity);
+	}
+
+	virtual Batch<const std::remove_const_t<T>> get(EntityID p_entity, Space p_mode = Space::LOCAL) const override {
+		return &storage.get(p_entity);
+	}
+
+	virtual Batch<std::remove_const_t<T>> get(EntityID p_entity, Space p_mode = Space::LOCAL) override {
+		StorageBase::notify_changed(p_entity);
+		return &storage.get(p_entity);
+	}
+
+	virtual void remove(EntityID p_entity) override {
+		storage.remove(p_entity);
+		// Make sure to remove as changed.
+		StorageBase::notify_updated(p_entity);
+	}
+
+	virtual void clear() override {
+		storage.clear();
+		StorageBase::flush_changed();
+	}
+
+	virtual EntitiesBuffer get_stored_entities() const {
+		return { storage.get_entities().size(), storage.get_entities().ptr() };
+	}
+};
+
+template <class T>
+class DynamicDenseVectorStorage : public DenseVectorStorage<T> {
+	DynamicComponentInfo *dynamic_componente_info = nullptr;
+
+public:
+	DynamicDenseVectorStorage(DynamicComponentInfo *p_info) :
+			dynamic_componente_info(p_info) {}
+
+	virtual void insert_dynamic(EntityID p_entity, const Dictionary &p_data) override {
+		T insert_data;
+
+		// Initialize with defaults.
+		insert_data.__initialize(dynamic_componente_info);
+
+		// Set the custom data if any
+		for (const Variant *key = p_data.next(); key; key = p_data.next(key)) {
+			T::set_by_name(&insert_data, StringName(*key), *p_data.getptr(*key));
+		}
+
+		this->insert(p_entity, insert_data);
+	}
+};

--- a/storage/steady_storage.h
+++ b/storage/steady_storage.h
@@ -4,7 +4,7 @@
 #include "dense_vector.h"
 #include "storage.h"
 
-/// Storage that is a lot useful when it's necessary to store big objects:
+/// Storage that is a lot useful when it's necessary to store big components:
 /// in those cases, you don't want to reallocate the memory each time a new
 /// entity is added or removed.
 ///
@@ -14,7 +14,8 @@
 /// to this storage it's possible to create components that are fixed in memory,
 /// so pass the pointer or internal component pointers is safe.
 ///
-/// Note, the allocated memory is contiguous.
+/// Note: The allocated memory is contiguous, but fragmented. Internally the
+/// storage creates some pages within the components are stored contiguosly.
 template <class T>
 class SteadyStorage : public Storage<T> {
 	PagedAllocator<T, false> allocator;

--- a/storage/steady_storage.h
+++ b/storage/steady_storage.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "core/templates/paged_allocator.h"
+#include "dense_vector.h"
+#include "storage.h"
+
+/// Storage that is a lot useful when it's necessary to store big objects:
+/// in those cases, you don't want to reallocate the memory each time a new
+/// entity is added or removed.
+///
+/// This storage is also useful when you are dealing with libraries like
+/// the physics engine, audio engine, etc... .
+/// With those libraries, it's usually necessary to create objects, so thanks
+/// to this storage it's possible to create components that are fixed in memory,
+/// so pass the pointer or internal component pointers is safe.
+///
+/// Note, the allocated memory is contiguous.
+template <class T>
+class SteadyStorage : public Storage<T> {
+	PagedAllocator<T, false> allocator;
+	DenseVector<T *> storage;
+
+public:
+	SteadyStorage(uint32_t p_page_size) :
+			allocator(p_page_size) {
+	}
+
+public:
+	virtual String get_type_name() const override {
+		return "SteadyStorage[" + String(typeid(T).name()) + "]";
+	}
+
+	virtual void insert(EntityID p_entity, const T &p_data) override {
+		T *d = allocator.alloc();
+		*d = p_data;
+		storage.insert(p_entity, d);
+		StorageBase::notify_changed(p_entity);
+	}
+
+	virtual bool has(EntityID p_entity) const override {
+		return storage.has(p_entity);
+	}
+
+	virtual Batch<const T> get(EntityID p_entity, Space p_mode = Space::LOCAL) const override {
+		return storage.get(p_entity);
+	}
+
+	virtual Batch<T> get(EntityID p_entity, Space p_mode = Space::LOCAL) override {
+		StorageBase::notify_changed(p_entity);
+		return storage.get(p_entity);
+	}
+
+	virtual void remove(EntityID p_entity) override {
+		ERR_FAIL_COND_MSG(storage.has(p_entity) == false, "No entity: " + itos(p_entity) + " in this storage.");
+		T *d = storage.get(p_entity);
+		storage.remove(p_entity);
+		allocator.free(d);
+		// Make sure to remove as changed.
+		StorageBase::notify_updated(p_entity);
+	}
+
+	virtual void clear() override {
+		allocator.reset();
+		storage.clear();
+		StorageBase::flush_changed();
+	}
+
+	virtual EntitiesBuffer get_stored_entities() const {
+		return { storage.get_entities().size(), storage.get_entities().ptr() };
+	}
+};

--- a/tests/test_ecs_paged_vector.h
+++ b/tests/test_ecs_paged_vector.h
@@ -1,0 +1,119 @@
+#ifndef TEST_STEADY_STORAGE_H
+#define TEST_STEADY_STORAGE_H
+
+#include "../components/component.h"
+#include "../storage/steady_storage.h"
+#include "core/math/math_funcs.h"
+
+#include "tests/test_macros.h"
+
+namespace godex_ecs_steady_storage_tests {
+
+struct SteadyComponentTest {
+	COMPONENT_CUSTOM_STORAGE(SteadyComponentTest)
+
+	int number = 0;
+
+	SteadyComponentTest(int i) :
+			number(i) {}
+};
+
+TEST_CASE("[SteadyStorage] Insert and iteration check.") {
+	// Create a storage with pages of 5 elements.
+	SteadyStorage<SteadyComponentTest> storage(5);
+
+	const uint32_t count = 100;
+	bool entities[count];
+
+	// Insert `count` elements and init the `entities` array with false.
+	for (uint32_t i = 0; i < count; i += 1) {
+		storage.insert(i, i);
+		entities[i] = false;
+	}
+
+	// For each stored element in the array, set true on the `entities` array.
+	const EntitiesBuffer buf = storage.get_stored_entities();
+	for (uint32_t i = 0; i < buf.count; i += 1) {
+		SteadyComponentTest *data = storage.get(buf.entities[i]);
+		entities[data->number] = true;
+	}
+
+	// Make sure each entity is set to true, confirming all got correctly stored.
+	for (uint32_t i = 0; i < count; i += 1) {
+		CHECK(entities[i]);
+	}
+}
+
+TEST_CASE("[SteadyStorage] Push and remove memory check.") {
+	SteadyStorage<SteadyComponentTest> storage(5);
+
+	const uint32_t count = 100;
+	SteadyComponentTest *pointers[count];
+
+	// Insert `count` elements and store the pointer.
+	for (uint32_t i = 0; i < count; i += 1) {
+		storage.insert(i, i);
+		pointers[i] = storage.get(i);
+	}
+
+	// For each pointer, make sure the memory is still valid after all the
+	// insert.
+	for (uint32_t i = 0; i < count; i += 1) {
+		CHECK(pointers[i] == storage.get(i).get_data());
+	}
+
+	// Remove some random pointers.
+	const uint32_t remove_count = count / 4;
+	for (uint32_t i = 0; i < remove_count; i += 1) {
+		const uint32_t entity_to_remove = Math::random(0, count - 1);
+		if (pointers[entity_to_remove]) {
+			// This pointer is still valid.
+			storage.remove(entity_to_remove);
+			pointers[entity_to_remove] = nullptr;
+		}
+	}
+
+	// Check the validity of remaining one.
+	for (uint32_t i = 0; i < count; i += 1) {
+		if (pointers[i]) {
+			CHECK(pointers[i] == storage.get(i).get_data());
+		}
+	}
+
+	// Validate the internal data.
+	for (uint32_t i = 0; i < count; i += 1) {
+		if (pointers[i]) {
+			CHECK(pointers[i]->number == i);
+		}
+	}
+
+	// Alter the internal data, using the pointers.
+	for (uint32_t i = 0; i < count; i += 1) {
+		if (pointers[i]) {
+			pointers[i]->number = -1;
+		}
+	}
+
+	// Make sure the storage data is also changed, and change the data taking
+	// it from the storage.
+	for (uint32_t i = 0; i < count; i += 1) {
+		if (pointers[i]) {
+			CHECK(storage.get(i)->number == -1);
+			storage.get(i)->number = i;
+		}
+	}
+
+	// Make sure pointers are still pointing to the same data.
+	for (uint32_t i = 0; i < count; i += 1) {
+		if (pointers[i]) {
+			CHECK(pointers[i]->number == i);
+		}
+	}
+
+	// At this point it's safe to assume that the data created is steady inplace
+	// until explictly removed, even if other entities are added or removed.
+	// All the pointers remain valid until explicitly removed.
+}
+} // namespace godex_ecs_steady_storage_tests
+
+#endif // TEST_STEADY_STORAGE_H

--- a/tests/test_ecs_storage_dense_vector.h
+++ b/tests/test_ecs_storage_dense_vector.h
@@ -4,7 +4,7 @@
 #include "tests/test_macros.h"
 
 #include "../components/component.h"
-#include "../storage/dense_vector.h"
+#include "../storage/dense_vector_storage.h"
 
 namespace godex_storage_dense_vector_tests {
 


### PR DESCRIPTION
The `SteadyStorage` is a lot useful when it's necessary to store big components: in those cases, you don't want to reallocate the memory each time a new entity is added or removed.

This storage is also useful when you are dealing with libraries like
the physics engine, audio engine, etc... .
With those libraries, it's usually necessary to create objects, so thanks
to this storage it's possible to create components that are fixed in memory,
so pass the pointer or internal component pointers is safe.

Note, the allocated memory is contiguous.