### PR TITLE
Added possibility to config per component Storage.

### DIFF
--- a/components/child.cpp
+++ b/components/child.cpp
@@ -5,6 +5,10 @@ void Child::_bind_methods() {
 	ECS_BIND_PROPERTY(Child, PropertyInfo(Variant::INT, "parent"), parent);
 }
 
+void Child::_get_storage_config(Dictionary &r_dictionary) {
+	r_dictionary["pre_allocate"] = 1000;
+}
+
 Child::Child(EntityID p_parent) :
 		parent(p_parent) {
 }

--- a/components/child.h
+++ b/components/child.h
@@ -6,6 +6,7 @@ class Child {
 	COMPONENT_CUSTOM_STORAGE(Child)
 
 	static void _bind_methods();
+	static void _get_storage_config(Dictionary &r_dictionary);
 
 public:
 	// The parent `Entity`.

--- a/ecs.cpp
+++ b/ecs.cpp
@@ -521,6 +521,7 @@ uint32_t ECS::register_script_component(const StringName &p_name, const LocalVec
 	components_info.push_back(
 			ComponentInfo{
 					nullptr,
+					nullptr,
 					info,
 					false,
 					false,
@@ -542,6 +543,10 @@ uint32_t ECS::register_script_component_event(const StringName &p_name, const Lo
 	return cid;
 }
 
+uint32_t ECS::get_components_count() {
+	return components.size();
+}
+
 bool ECS::verify_component_id(uint32_t p_component_id) {
 	return components.size() > p_component_id;
 }
@@ -557,5 +562,12 @@ StorageBase *ECS::create_storage(uint32_t p_component_id) {
 	} else {
 		// This is a native component.
 		return components_info[p_component_id].create_storage();
+	}
+}
+
+void ECS::get_storage_config(godex::component_id p_component_id, Dictionary &r_config) {
+	ERR_FAIL_COND_MSG(ECS::verify_component_id(p_component_id) == false, "This component doesn't exists: " + itos(p_component_id));
+	if (components_info[p_component_id].get_storage_config != nullptr) {
+		components_info[p_component_id].get_storage_config(r_config);
 	}
 }

--- a/ecs.h
+++ b/ecs.h
@@ -34,6 +34,7 @@ struct DataAccessorFuncs {
 /// component registration.
 struct ComponentInfo {
 	StorageBase *(*create_storage)();
+	void (*get_storage_config)(Dictionary &);
 	DynamicComponentInfo *dynamic_component_info = nullptr;
 	bool notify_release_write = false;
 	bool is_event = false;
@@ -114,9 +115,11 @@ public:
 	static uint32_t register_script_component(const StringName &p_name, const LocalVector<ScriptProperty> &p_properties, StorageType p_storage_type);
 	static uint32_t register_script_component_event(const StringName &p_name, const LocalVector<ScriptProperty> &p_properties, StorageType p_storage_type);
 
+	static uint32_t get_components_count();
 	static bool verify_component_id(uint32_t p_component_id);
 
 	static StorageBase *create_storage(godex::component_id p_component_id);
+	static void get_storage_config(godex::component_id p_component_id, Dictionary &r_config);
 	static const LocalVector<StringName> &get_registered_components();
 	static godex::component_id get_component_id(StringName p_component_name);
 	static StringName get_component_name(godex::component_id p_component_id);
@@ -312,10 +315,16 @@ void ECS::register_component(StorageBase *(*create_storage)()) {
 		C::_bind_methods();
 	}
 
+	void (*get_storage_config)(Dictionary &) = nullptr;
+	if constexpr (godex_has_storage_config<C>::value) {
+		get_storage_config = C::_get_storage_config;
+	}
+
 	components.push_back(component_name);
 	components_info.push_back(
 			ComponentInfo{
 					create_storage,
+					get_storage_config,
 					nullptr,
 					notify_release_write,
 					false,

--- a/ecs.h
+++ b/ecs.h
@@ -307,7 +307,11 @@ void ECS::register_component(StorageBase *(*create_storage)()) {
 
 	StringName component_name = C::get_class_static();
 	C::component_id = components.size();
-	C::_bind_methods();
+
+	if constexpr (godex_has_bind_methods<C>::value) {
+		C::_bind_methods();
+	}
+
 	components.push_back(component_name);
 	components_info.push_back(
 			ComponentInfo{

--- a/ecs_types.h
+++ b/ecs_types.h
@@ -475,3 +475,11 @@ public:
 	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override;
 	virtual Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 };
+
+struct PropertyInfoWithDefault {
+	PropertyInfo info;
+	Variant def;
+
+	PropertyInfoWithDefault(PropertyInfo &p_info, const Variant &p_def) :
+			info(p_info), def(p_def) {}
+};

--- a/ecs_types.h
+++ b/ecs_types.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* Author: AndreaCatania */
-
 #include "core/object/object.h"
 #include "core/object/script_language.h"
 #include "core/string/ustring.h"
@@ -10,14 +8,17 @@
 #include "core/variant/binder_common.h"
 #include "modules/gdscript/gdscript.h"
 
-template <bool B>
-struct bool_type {};
+template <typename T, typename = void>
+struct godex_has_bind_methods : std::false_type {};
 
-template <typename Test, template <typename...> class Ref>
-struct is_specialization : bool_type<false> {};
+template <typename T>
+struct godex_has_bind_methods<T, decltype(void(std::declval<T &>()._bind_methods()))> : std::true_type {};
 
-template <template <typename...> class Ref, typename... Args>
-struct is_specialization<Ref<Args...>, Ref> : bool_type<true> {};
+template <typename T, typename = void>
+struct godex_has_storage_config : std::false_type {};
+
+template <typename T>
+struct godex_has_storage_config<T, decltype(void(std::declval<T &>()._get_storage_config(std::declval<Dictionary &>())))> : std::true_type {};
 
 #define ECSCLASS(m_class)                             \
 private:                                              \

--- a/godot/components/transform_component.cpp
+++ b/godot/components/transform_component.cpp
@@ -2,6 +2,14 @@
 
 /* Author: AndreaCatania */
 
+void TransformComponent::_bind_methods() {
+	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform"), transform);
+}
+
+void TransformComponent::_get_storage_config(Dictionary &r_dictionary) {
+	r_dictionary["pre_allocate"] = 1000;
+}
+
 TransformComponent::TransformComponent(const Transform &p_transform) :
 		transform(p_transform) {
 }
@@ -18,8 +26,4 @@ void TransformComponent::combine_inverse(
 		const TransformComponent &p_parent_global,
 		TransformComponent &r_local) {
 	r_local.transform = p_parent_global.transform.inverse() * p_global.transform;
-}
-
-void TransformComponent::_bind_methods() {
-	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform"), transform);
 }

--- a/godot/components/transform_component.h
+++ b/godot/components/transform_component.h
@@ -8,6 +8,7 @@
 class TransformComponent {
 	COMPONENT(TransformComponent, HierarchicalStorage)
 	static void _bind_methods();
+	static void _get_storage_config(Dictionary &r_dictionary);
 
 	Transform transform;
 

--- a/godot/components/transform_component.h
+++ b/godot/components/transform_component.h
@@ -7,6 +7,7 @@
 
 class TransformComponent {
 	COMPONENT(TransformComponent, HierarchicalStorage)
+	static void _bind_methods();
 
 	Transform transform;
 
@@ -25,7 +26,4 @@ class TransformComponent {
 			const TransformComponent &p_global,
 			const TransformComponent &p_parent_global,
 			TransformComponent &r_local);
-
-protected:
-	static void _bind_methods();
 };

--- a/godot/nodes/ecs_world.h
+++ b/godot/nodes/ecs_world.h
@@ -130,6 +130,9 @@ public:
 	void set_active_pipeline(StringName p_name);
 	StringName get_active_pipeline() const;
 
+	void set_storages_config(Dictionary p_config);
+	Dictionary get_storages_config() const;
+
 	// ~~ Runtime API ~~
 private:
 	DataAccessor component_accessor;

--- a/storage/dense_vector.h
+++ b/storage/dense_vector.h
@@ -65,14 +65,38 @@ public:
 		entity_to_data[p_entity] = UINT32_MAX;
 	}
 
+	const LocalVector<EntityID> &get_entities() const {
+		return data_to_entity;
+	}
+
+	/// Clear the storage.
 	void clear() {
 		data.clear();
 		data_to_entity.clear();
 		entity_to_data.clear();
 	}
 
-	const LocalVector<EntityID> &get_entities() const {
-		return data_to_entity;
+	/// Reset the storage unallocating the memory.
+	void reset() {
+		data.reset();
+		data_to_entity.reset();
+		entity_to_data.reset();
+	}
+
+	/// Preallocate a given size, avoid useless allocations.
+	/// Note, never call this if there are stored data: before call always
+	/// `clear`.
+	void configure(uint32_t p_reserve) {
+		CRASH_COND_MSG(data.size() != 0, "Please call `clear` before `configure`.");
+
+		data.reserve(p_reserve);
+		data_to_entity.reserve(p_reserve);
+		entity_to_data.reserve(p_reserve);
+
+		entity_to_data.resize(p_reserve);
+		for (uint32_t i = 0; i < p_reserve; i += 1) {
+			entity_to_data[i] = UINT32_MAX;
+		}
 	}
 
 protected:

--- a/storage/dense_vector_storage.h
+++ b/storage/dense_vector_storage.h
@@ -15,6 +15,11 @@ protected:
 	DenseVector<T> storage;
 
 public:
+	virtual void configure(const Dictionary &p_config) override {
+		storage.reset();
+		storage.configure(p_config.get("pre_allocate", 500));
+	}
+
 	virtual String get_type_name() const override {
 		return "DenseVector[" + String(typeid(T).name()) + "]";
 	}

--- a/storage/hierarchical_storage.h
+++ b/storage/hierarchical_storage.h
@@ -22,6 +22,11 @@ class Hierarchy : public Storage<Child> {
 	LocalVector<HierarchicalStorageBase *> sub_storages;
 
 public:
+	void configure(const Dictionary &p_config) {
+		storage.reset();
+		storage.configure(p_config.get("pre_allocate", 500));
+	}
+
 	void add_sub_storage(HierarchicalStorageBase *p_storage) {
 		CRASH_COND_MSG(p_storage->hierarchy != nullptr, "This hierarchy storage is already added to another `Hierarchy`.");
 		sub_storages.push_back(p_storage);
@@ -278,6 +283,11 @@ class HierarchicalStorage : public Storage<T>, public HierarchicalStorageBase {
 	EntityList relationshitp_dirty_list;
 
 public:
+	void configure(const Dictionary &p_config) {
+		internal_storage.reset();
+		internal_storage.configure(p_config.get("pre_allocate", 500));
+	}
+
 	virtual String get_type_name() const override {
 		return "HierarchicalStorage[" + String(typeid(T).name()) + "]";
 	}

--- a/storage/shared_steady_storage.h
+++ b/storage/shared_steady_storage.h
@@ -17,11 +17,11 @@ class SharedSteadyStorage : public SharedStorage<T> {
 	DenseVector<godex::SID> storage;
 
 public:
-	SharedSteadyStorage(uint32_t p_page_size) :
-			allocator(p_page_size) {
+	virtual void configure(const Dictionary &p_config) override {
+		clear();
+		allocator.configure(p_config.get("page_size", 200));
 	}
 
-public:
 	virtual String get_type_name() const override {
 		return "SteadyStorage[" + String(typeid(T).name()) + "]";
 	}

--- a/storage/steady_storage.h
+++ b/storage/steady_storage.h
@@ -22,11 +22,11 @@ class SteadyStorage : public Storage<T> {
 	DenseVector<T *> storage;
 
 public:
-	SteadyStorage(uint32_t p_page_size) :
-			allocator(p_page_size) {
+	virtual void configure(const Dictionary &p_config) override {
+		clear();
+		allocator.configure(p_config.get("page_size", 200));
 	}
 
-public:
 	virtual String get_type_name() const override {
 		return "SteadyStorage[" + String(typeid(T).name()) + "]";
 	}

--- a/storage/storage.h
+++ b/storage/storage.h
@@ -22,6 +22,10 @@ class StorageBase {
 	EntityList changed;
 
 public:
+	/// This function is called each time this storage is initialized.
+	/// It's possible to provide configuration by passing a dictionary.
+	virtual void configure(const Dictionary &p_config) {}
+
 	virtual ~StorageBase() {}
 	virtual String get_type_name() const { return "Overload this function `get_type_name()` please."; }
 

--- a/tests/test_ecs_storage_shared_steady.h
+++ b/tests/test_ecs_storage_shared_steady.h
@@ -19,7 +19,10 @@ struct SharedSteadyComponentTest {
 };
 
 TEST_CASE("[SharedSteadyStorage] Check memory share.") {
-	SharedSteadyStorage<SharedSteadyComponentTest> storage(5);
+	SharedSteadyStorage<SharedSteadyComponentTest> storage;
+	Dictionary config;
+	config["page_size"] = 5;
+	storage.configure(config);
 
 	const godex::SID shared_component_id_1 = storage.create_shared_component(
 			SharedSteadyComponentTest(10));
@@ -111,7 +114,10 @@ TEST_CASE("[SharedSteadyStorage] Check memory share.") {
 }
 
 TEST_CASE("[SharedSteadyStorage] Check memory steadness.") {
-	SharedSteadyStorage<SharedSteadyComponentTest> storage(5);
+	SharedSteadyStorage<SharedSteadyComponentTest> storage;
+	Dictionary config;
+	config["page_size"] = 5;
+	storage.configure(config);
 
 	const godex::SID shared_component_id_1 = storage.create_shared_component(
 			SharedSteadyComponentTest(10));

--- a/tests/test_ecs_storage_steady.h
+++ b/tests/test_ecs_storage_steady.h
@@ -20,7 +20,10 @@ struct SteadyComponentTest {
 
 TEST_CASE("[SteadyStorage] Insert and iteration check.") {
 	// Create a storage with pages of 5 elements.
-	SteadyStorage<SteadyComponentTest> storage(5);
+	SteadyStorage<SteadyComponentTest> storage;
+	Dictionary config;
+	config["page_size"] = 5;
+	storage.configure(config);
 
 	const uint32_t count = 100;
 	bool entities[count];
@@ -45,7 +48,10 @@ TEST_CASE("[SteadyStorage] Insert and iteration check.") {
 }
 
 TEST_CASE("[SteadyStorage] Push and remove memory check.") {
-	SteadyStorage<SteadyComponentTest> storage(5);
+	SteadyStorage<SteadyComponentTest> storage;
+	Dictionary config;
+	config["page_size"] = 5;
+	storage.configure(config);
 
 	const uint32_t count = 100;
 	SteadyComponentTest *pointers[count];

--- a/world/world.cpp
+++ b/world/world.cpp
@@ -166,6 +166,20 @@ void World::create_storage(uint32_t p_component_id) {
 		Hierarchy *hierarchy = static_cast<Hierarchy *>(get_storage<Child>());
 		hierarchy->add_sub_storage(hs);
 	}
+
+	// Search the config for this storage.
+	Dictionary config = storages_config.get(
+			ECS::get_component_name(p_component_id),
+			storages_config.get(
+					String(ECS::get_component_name(p_component_id)),
+					Dictionary()));
+
+	if (config.size() == 0) {
+		// At this point the config is undefined, so take the default.
+		ECS::get_storage_config(p_component_id, config);
+	}
+
+	storages[p_component_id]->configure(config);
 }
 
 void World::destroy_storage(uint32_t p_component_id) {

--- a/world/world.h
+++ b/world/world.h
@@ -87,6 +87,12 @@ class World : public godex::Databag {
 	EntityBuilder entity_builder = EntityBuilder(this);
 	bool is_dispatching_in_progress = false;
 
+	/// Storages configuration, the format is as follows:
+	/// {"Component Name" :{"param_1": 11, "param_2": 11},
+	///  "Component Name" :{"param_1": 11, "param_2": 11},
+	///  "Component Name" :{"param_1": 11, "param_2": 11}}
+	Dictionary storages_config;
+
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
- `_bind_methods` is optional again.
- Added possibility to config per component Storage.
Now each component can define how to config its own storage: depending
on the storage used it's possible to define pre_allocation and
page_size.

![ezgif com-video-to-gif(8)](https://user-images.githubusercontent.com/8342599/109412847-9a983680-79aa-11eb-9e9b-3269d13f3e5c.gif)
