### PR TITLE
Refactored Query mechanisn - Nesting mechanics.

### DIFF
--- a/components/component.cpp
+++ b/components/component.cpp
@@ -1,3 +1,0 @@
-#include "component.h"
-
-/** @author AndreaCatania */

--- a/components/component.h
+++ b/components/component.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* Author: AndreaCatania */
-
 #include "../ecs.h"
 #include "../storage/batch_storage.h"
 #include "../storage/dense_vector_storage.h"

--- a/databags/databag.cpp
+++ b/databags/databag.cpp
@@ -1,3 +1,0 @@
-#include "databag.h"
-
-/** @author AndreaCatania */

--- a/databags/databag.h
+++ b/databags/databag.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* Author: AndreaCatania */
-
 #include "../ecs_types.h"
 #include "core/object/class_db.h"
 #include "core/object/object.h"

--- a/doc_classes/DynamicQuery.xml
+++ b/doc_classes/DynamicQuery.xml
@@ -86,7 +86,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="without_component">
+		<method name="not_component">
 			<return type="void">
 			</return>
 			<argument index="0" name="component_id" type="int">

--- a/doc_classes/System.xml
+++ b/doc_classes/System.xml
@@ -64,7 +64,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="without_component">
+		<method name="not_component">
 			<return type="void">
 			</return>
 			<argument index="0" name="component_id" type="int">

--- a/ecs.h
+++ b/ecs.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* Author: AndreaCatania */
-
 #include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/templates/local_vector.h"

--- a/iterators/dynamic_query.cpp
+++ b/iterators/dynamic_query.cpp
@@ -10,7 +10,7 @@ void DynamicQuery::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("with_component", "component_id", "mutable"), &DynamicQuery::with_component);
 	ClassDB::bind_method(D_METHOD("maybe_component", "component_id", "mutable"), &DynamicQuery::maybe_component);
 	ClassDB::bind_method(D_METHOD("changed_component", "component_id", "mutable"), &DynamicQuery::changed_component);
-	ClassDB::bind_method(D_METHOD("without_component", "component_id"), &DynamicQuery::without_component);
+	ClassDB::bind_method(D_METHOD("not_component", "component_id"), &DynamicQuery::not_component);
 
 	ClassDB::bind_method(D_METHOD("is_valid"), &DynamicQuery::is_valid);
 	ClassDB::bind_method(D_METHOD("build"), &DynamicQuery::build);
@@ -49,7 +49,7 @@ void DynamicQuery::changed_component(uint32_t p_component_id, bool p_mutable) {
 	_with_component(p_component_id, p_mutable, CHANGED_MODE);
 }
 
-void DynamicQuery::without_component(uint32_t p_component_id) {
+void DynamicQuery::not_component(uint32_t p_component_id) {
 	_with_component(p_component_id, false, WITHOUT_MODE);
 }
 

--- a/iterators/dynamic_query.h
+++ b/iterators/dynamic_query.h
@@ -52,7 +52,7 @@ public:
 	void changed_component(uint32_t p_component_id, bool p_mutable = false);
 
 	/// Excludes this component from the query.
-	void without_component(uint32_t p_component_id);
+	void not_component(uint32_t p_component_id);
 
 	void _with_component(uint32_t p_component_id, bool p_mutable, FetchMode p_mode);
 

--- a/iterators/query.cpp
+++ b/iterators/query.cpp
@@ -1,1 +1,0 @@
-/** @author AndreaCatania */

--- a/iterators/query.h
+++ b/iterators/query.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "../storage/storage.h"
 #include "../systems/system.h"

--- a/iterators/query.h
+++ b/iterators/query.h
@@ -1,6 +1,4 @@
-﻿/** @author AndreaCatania */
-
-#pragma once
+﻿#pragma once
 
 #include "../storage/storage.h"
 #include "../systems/system.h"

--- a/modules/godot/components/mesh_component.cpp
+++ b/modules/godot/components/mesh_component.cpp
@@ -1,7 +1,5 @@
 #include "mesh_component.h"
 
-/* Author: AndreaCatania */
-
 void MeshComponent::_bind_methods() {
 	ECS_BIND_PROPERTY(MeshComponent, PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), mesh);
 	ECS_BIND_PROPERTY(MeshComponent, PropertyInfo(Variant::OBJECT, "material_override", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,StandardMaterial3D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_DEFERRED_SET_RESOURCE), material_override);

--- a/modules/godot/components/mesh_component.h
+++ b/modules/godot/components/mesh_component.h
@@ -1,5 +1,3 @@
-/** @author: AndreaCatania */
-
 #ifndef MESH_COMPONENT_H
 #define MESH_COMPONENT_H
 

--- a/modules/godot/components/transform_component.cpp
+++ b/modules/godot/components/transform_component.cpp
@@ -1,7 +1,5 @@
 #include "transform_component.h"
 
-/* Author: AndreaCatania */
-
 void TransformComponent::_bind_methods() {
 	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform"), transform);
 }

--- a/modules/godot/editor_plugins/editor_world_ecs.cpp
+++ b/modules/godot/editor_plugins/editor_world_ecs.cpp
@@ -1,5 +1,3 @@
-/* Author: AndreaCatania */
-
 #include "editor_world_ecs.h"
 
 #include "../../../ecs.h"

--- a/modules/godot/editor_plugins/editor_world_ecs.h
+++ b/modules/godot/editor_plugins/editor_world_ecs.h
@@ -1,5 +1,3 @@
-/* Author: AndreaCatania */
-
 #ifndef EDITORWORLDECS_H
 #define EDITORWORLDECS_H
 

--- a/modules/godot/editor_plugins/entity_editor_plugin.cpp
+++ b/modules/godot/editor_plugins/entity_editor_plugin.cpp
@@ -1,5 +1,3 @@
-/* Author: AndreaCatania */
-
 #include "entity_editor_plugin.h"
 #include "../nodes/ecs_utilities.h"
 #include "../nodes/entity.h"

--- a/modules/godot/editor_plugins/entity_editor_plugin.h
+++ b/modules/godot/editor_plugins/entity_editor_plugin.h
@@ -1,5 +1,3 @@
-/* Author: AndreaCatania */
-
 #ifndef ENTITY_EDITOR_PLUGIN_H
 #define ENTITY_EDITOR_PLUGIN_H
 

--- a/modules/godot/nodes/ecs_utilities.cpp
+++ b/modules/godot/nodes/ecs_utilities.cpp
@@ -14,7 +14,7 @@ void System::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("with_component", "component_id", "mutability"), &System::with_component);
 	ClassDB::bind_method(D_METHOD("maybe_component", "component_id", "mutability"), &System::maybe_component);
 	ClassDB::bind_method(D_METHOD("changed_component", "component_id", "mutability"), &System::changed_component);
-	ClassDB::bind_method(D_METHOD("without_component", "component_id"), &System::without_component);
+	ClassDB::bind_method(D_METHOD("not_component", "component_id"), &System::not_component);
 
 	ClassDB::bind_method(D_METHOD("get_current_entity_id"), &System::get_current_entity_id);
 
@@ -88,9 +88,9 @@ void System::changed_component(uint32_t p_component_id, Mutability p_mutability)
 	info->changed_component(p_component_id, p_mutability == MUTABLE);
 }
 
-void System::without_component(uint32_t p_component_id) {
+void System::not_component(uint32_t p_component_id) {
 	ERR_FAIL_COND_MSG(prepare_in_progress == false, "No info set. This function can be called only within the `_prepare`.");
-	info->without_component(p_component_id);
+	info->not_component(p_component_id);
 }
 
 godex::system_id System::get_system_id() const {

--- a/modules/godot/nodes/ecs_utilities.h
+++ b/modules/godot/nodes/ecs_utilities.h
@@ -41,7 +41,7 @@ public:
 	void with_component(uint32_t p_component_id, Mutability p_mutability);
 	void maybe_component(uint32_t p_component_id, Mutability p_mutability);
 	void changed_component(uint32_t p_component_id, Mutability p_mutability);
-	void without_component(uint32_t p_component_id);
+	void not_component(uint32_t p_component_id);
 
 	godex::system_id get_system_id() const;
 

--- a/modules/godot/nodes/ecs_world.cpp
+++ b/modules/godot/nodes/ecs_world.cpp
@@ -1,6 +1,4 @@
 
-/* Author: AndreaCatania */
-
 #include "ecs_world.h"
 
 #include "../../../ecs.h"

--- a/modules/godot/nodes/ecs_world.h
+++ b/modules/godot/nodes/ecs_world.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* Author: AndreaCatania */
-
 #include "../../../components/component.h"
 #include "../../../ecs_types.h"
 #include "scene/main/node.h"

--- a/modules/godot/nodes/entity.h
+++ b/modules/godot/nodes/entity.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* Author: AndreaCatania */
-
 #include "../../../components/child.h"
 #include "core/templates/local_vector.h"
 #include "ecs_utilities.h"

--- a/pipeline/pipeline.h
+++ b/pipeline/pipeline.h
@@ -1,9 +1,5 @@
 #pragma once
 
-/**
-	@author AndreaCatania
-*/
-
 #include "../ecs.h"
 #include "../systems/system.h"
 #include "core/templates/local_vector.h"

--- a/register_types.h
+++ b/register_types.h
@@ -1,8 +1,4 @@
 #pragma once
 
-/**
-	@author AndreaCatania
-*/
-
 void register_godex_types();
 void unregister_godex_types();

--- a/storage/batch_storage.h
+++ b/storage/batch_storage.h
@@ -1,5 +1,3 @@
-/* Author: AndreaCatania */
-
 #pragma once
 
 #include "../ecs.h"

--- a/storage/dense_vector.h
+++ b/storage/dense_vector.h
@@ -1,4 +1,3 @@
-/* Author: AndreaCatania */
 #pragma once
 
 #include "../ecs.h"

--- a/storage/dense_vector_storage.h
+++ b/storage/dense_vector_storage.h
@@ -1,4 +1,3 @@
-/* Author: AndreaCatania */
 #pragma once
 
 #include "../ecs.h"

--- a/systems/dynamic_system.cpp
+++ b/systems/dynamic_system.cpp
@@ -81,13 +81,13 @@ void godex::DynamicSystemInfo::changed_component(uint32_t p_component_id, bool p
 	query->changed_component(p_component_id, p_mutable);
 }
 
-void godex::DynamicSystemInfo::without_component(uint32_t p_component_id) {
+void godex::DynamicSystemInfo::not_component(uint32_t p_component_id) {
 	CRASH_COND_MSG(compiled, "The query can't be composed, when the system is already been compiled.");
 
 	init_query();
 	const uint32_t index = databag_element_map.size() + storage_element_map.size() + query_element_map.size();
 	query_element_map.push_back(index);
-	query->without_component(p_component_id);
+	query->not_component(p_component_id);
 }
 
 void godex::DynamicSystemInfo::with_storage(godex::component_id p_component_id) {

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -1,5 +1,3 @@
-/** @author AndreaCatania */
-
 #pragma once
 
 #include "../iterators/dynamic_query.h"

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -81,7 +81,7 @@ public:
 	void with_component(uint32_t p_component_id, bool p_mutable);
 	void maybe_component(uint32_t p_component_id, bool p_mutable);
 	void changed_component(uint32_t p_component_id, bool p_mutable);
-	void without_component(uint32_t p_component_id);
+	void not_component(uint32_t p_component_id);
 	void with_storage(godex::component_id p_component_id);
 
 	void set_target(func_system_execute_pipeline p_sub_pipeline_execite);

--- a/systems/system.h
+++ b/systems/system.h
@@ -1,5 +1,3 @@
-/** @author AndreaCatania */
-
 #pragma once
 
 #include "core/string/string_name.h"

--- a/systems/system_builder.h
+++ b/systems/system_builder.h
@@ -1,6 +1,3 @@
-
-/** @author AndreaCatania */
-
 #pragma once
 
 #include "../databags/databag.h"

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -82,11 +82,11 @@ TEST_CASE("[Modules][ECS] Test fetch element type using fetch_element_type.") {
 		float gg = 20;
 		bool bb = 30;
 		EntityID ee;
-		fetch_element_type<0, 0, Without<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> ptr_xx = &xx;
-		fetch_element_type<1, 0, Without<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> ptr_jj = &jj;
-		fetch_element_type<2, 0, Without<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> ptr_gg = &gg;
-		fetch_element_type<3, 0, Without<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> ptr_bb = &bb;
-		fetch_element_type<4, 0, Without<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> entity = ee;
+		fetch_element_type<0, 0, Not<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> ptr_xx = &xx;
+		fetch_element_type<1, 0, Not<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> ptr_jj = &jj;
+		fetch_element_type<2, 0, Not<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> ptr_gg = &gg;
+		fetch_element_type<3, 0, Not<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> ptr_bb = &bb;
+		fetch_element_type<4, 0, Not<int>, Any<int, Changed<float>>, Maybe<bool>, EntityID> entity = ee;
 		CHECK(ptr_xx == &xx);
 		CHECK(ptr_jj == &jj);
 		CHECK(ptr_gg == &gg);
@@ -101,11 +101,11 @@ TEST_CASE("[Modules][ECS] Test fetch element type using fetch_element_type.") {
 		float gg = 20;
 		bool bb = 30;
 		EntityID ee;
-		fetch_element_type<0, 0, Without<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> ptr_xx = &xx;
-		fetch_element_type<1, 0, Without<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> ptr_jj = &jj;
-		fetch_element_type<2, 0, Without<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> ptr_gg(&gg, 1);
-		fetch_element_type<3, 0, Without<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> ptr_bb = &bb;
-		fetch_element_type<4, 0, Without<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> entity = ee;
+		fetch_element_type<0, 0, Not<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> ptr_xx = &xx;
+		fetch_element_type<1, 0, Not<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> ptr_jj = &jj;
+		fetch_element_type<2, 0, Not<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> ptr_gg(&gg, 1);
+		fetch_element_type<3, 0, Not<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> ptr_bb = &bb;
+		fetch_element_type<4, 0, Not<int>, Any<int, Batch<Changed<float>>>, Maybe<bool>, EntityID> entity = ee;
 		CHECK(ptr_xx == &xx);
 		CHECK(ptr_jj == &jj);
 		CHECK(ptr_gg.is_empty() == false);
@@ -122,11 +122,11 @@ TEST_CASE("[Modules][ECS] Test fetch element type using fetch_element_type.") {
 		float gg = 20;
 		bool bb = 30;
 		EntityID ee;
-		fetch_element_type<0, 0, Without<int>, Any<Without<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> ptr_xx = &xx;
-		fetch_element_type<1, 0, Without<int>, Any<Without<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> ptr_jj = &jj;
-		fetch_element_type<2, 0, Without<int>, Any<Without<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> batch_gg(&gg, 1);
-		fetch_element_type<3, 0, Without<int>, Any<Without<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> ptr_bb = &bb;
-		fetch_element_type<4, 0, Without<int>, Any<Without<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> entity = ee;
+		fetch_element_type<0, 0, Not<int>, Any<Not<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> ptr_xx = &xx;
+		fetch_element_type<1, 0, Not<int>, Any<Not<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> ptr_jj = &jj;
+		fetch_element_type<2, 0, Not<int>, Any<Not<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> batch_gg(&gg, 1);
+		fetch_element_type<3, 0, Not<int>, Any<Not<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> ptr_bb = &bb;
+		fetch_element_type<4, 0, Not<int>, Any<Not<Changed<int>>, Batch<Maybe<Changed<float>>>>, Maybe<bool>, EntityID> entity = ee;
 		CHECK(ptr_xx == &xx);
 		CHECK(ptr_jj == &jj);
 		CHECK(batch_gg.is_empty() == false);
@@ -142,10 +142,10 @@ TEST_CASE("[Modules][ECS] Test fetch element type using fetch_element_type.") {
 		TagA gg;
 		bool bb = 30;
 		EntityID ee;
-		fetch_element_type<0, 0, Without<int>, Join<Any<Without<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>, Maybe<bool>, EntityID> ptr_xx = &xx;
-		fetch_element_type<1, 0, Without<int>, Join<Any<Without<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>, Maybe<bool>, EntityID> join(&gg, TagA::get_component_id(), false);
-		fetch_element_type<2, 0, Without<int>, Join<Any<Without<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>, Maybe<bool>, EntityID> ptr_bb = &bb;
-		fetch_element_type<3, 0, Without<int>, Join<Any<Without<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>, Maybe<bool>, EntityID> entity = ee;
+		fetch_element_type<0, 0, Not<int>, Join<Any<Not<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>, Maybe<bool>, EntityID> ptr_xx = &xx;
+		fetch_element_type<1, 0, Not<int>, Join<Any<Not<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>, Maybe<bool>, EntityID> join(&gg, TagA::get_component_id(), false);
+		fetch_element_type<2, 0, Not<int>, Join<Any<Not<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>, Maybe<bool>, EntityID> ptr_bb = &bb;
+		fetch_element_type<3, 0, Not<int>, Join<Any<Not<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>, Maybe<bool>, EntityID> entity = ee;
 		CHECK(ptr_xx == &xx);
 		CHECK(join.is_null() == false);
 		CHECK(join.is<TagA>());
@@ -160,10 +160,10 @@ TEST_CASE("[Modules][ECS] Test fetch element type using fetch_element_type.") {
 		TagA gg;
 		bool bb = 30;
 		EntityID ee;
-		fetch_element_type<0, 0, Any<Without<Changed<int>>, Join<Any<Without<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>>, Maybe<bool>, EntityID> ptr_xx = &xx;
-		fetch_element_type<1, 0, Any<Without<Changed<int>>, Join<Any<Without<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>>, Maybe<bool>, EntityID> join(&gg, TagA::get_component_id(), false);
-		fetch_element_type<2, 0, Any<Without<Changed<int>>, Join<Any<Without<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>>, Maybe<bool>, EntityID> ptr_bb = &bb;
-		fetch_element_type<3, 0, Any<Without<Changed<int>>, Join<Any<Without<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>>, Maybe<bool>, EntityID> entity = ee;
+		fetch_element_type<0, 0, Any<Not<Changed<int>>, Join<Any<Not<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>>, Maybe<bool>, EntityID> ptr_xx = &xx;
+		fetch_element_type<1, 0, Any<Not<Changed<int>>, Join<Any<Not<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>>, Maybe<bool>, EntityID> join(&gg, TagA::get_component_id(), false);
+		fetch_element_type<2, 0, Any<Not<Changed<int>>, Join<Any<Not<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>>, Maybe<bool>, EntityID> ptr_bb = &bb;
+		fetch_element_type<3, 0, Any<Not<Changed<int>>, Join<Any<Not<Changed<TagA>>, Batch<Maybe<Changed<TagB>>>>>>, Maybe<bool>, EntityID> entity = ee;
 		CHECK(ptr_xx == &xx);
 		CHECK(join.is_null() == false);
 		CHECK(join.is<TagA>());
@@ -277,7 +277,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test other filters
 	{
-		QueryResultTuple<Without<TagA>, Maybe<TagB>, Changed<TagC>> tuple;
+		QueryResultTuple<Not<TagA>, Maybe<TagB>, Changed<TagC>> tuple;
 
 		set<0>(tuple, &a);
 		set<1>(tuple, &b);
@@ -430,7 +430,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test deep all filters.
 	{
-		QueryResultTuple<EntityID, Any<Maybe<Changed<TagC>>, Batch<Maybe<Changed<TagB>>>>, Join<Any<Without<TagA>, Changed<TagB>>>> tuple;
+		QueryResultTuple<EntityID, Any<Maybe<Changed<TagC>>, Batch<Maybe<Changed<TagB>>>>, Join<Any<Not<TagA>, Changed<TagB>>>> tuple;
 
 		static_assert(tuple.SIZE == 4);
 
@@ -472,9 +472,9 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 				Any<
 						Maybe<Changed<TagC>>,
 						Batch<Maybe<Changed<TagB>>>,
-						Join<Any<Without<TagA>, Changed<TagB>>>,
+						Join<Any<Not<TagA>, Changed<TagB>>>,
 						Any<
-								Without<Changed<TagA>>,
+								Not<Changed<TagA>>,
 								Changed<TagB>>>,
 				EntityID,
 				TransformComponent>
@@ -557,7 +557,7 @@ TEST_CASE("[Modules][ECS] Test static query") {
 
 	// Test `Without` filter.
 	{
-		Query<const TransformComponent, Without<TagQueryTestComponent>> query(&world);
+		Query<const TransformComponent, Not<TagQueryTestComponent>> query(&world);
 
 		// This query fetches the entity that have only the `TransformComponent`.
 		CHECK(query.has(entity_1) == false);
@@ -631,7 +631,7 @@ TEST_CASE("[Modules][ECS] Test static query deep nesting") {
 	// Test `EntityID`, `With` `Maybe`, `Without + Changed`.
 	{
 		// Take this only if `TagC` DOESN'T changed.
-		Query<EntityID, TagA, Maybe<TagB>, Without<Changed<TagC>>> query(&world);
+		Query<EntityID, TagA, Maybe<TagB>, Not<Changed<TagC>>> query(&world);
 
 		// The `TagC` on the `Entity1` is changed, so the query doesn't fetches it.
 		CHECK(query.has(entity_1) == false);
@@ -643,8 +643,11 @@ TEST_CASE("[Modules][ECS] Test static query deep nesting") {
 		CHECK(entity == entity_2);
 		CHECK(tag_a != nullptr);
 		CHECK(tag_b != nullptr);
-		CHECK(tag_c == nullptr);
+		CHECK(tag_c != nullptr); // It's not changed, but exist.
 	}
+
+	// Needed because the above fetches mutably.
+	world.get_storage<TagC>()->notify_updated(entity_2);
 
 	// Test `EntityID`, `With`, `Maybe + Changed`.
 	{
@@ -662,7 +665,7 @@ TEST_CASE("[Modules][ECS] Test static query deep nesting") {
 			CHECK(tag_c != nullptr);
 		}
 
-		// In Entity2 the tag is NOT changed, we expect nullptr.
+		// In Entity2 the tag is NOT changed, nullptr expected.
 		{
 			auto [entity, tag_a, tag_c] = query[entity_2];
 			CHECK(entity == entity_2);
@@ -906,7 +909,7 @@ TEST_CASE("[Modules][ECS] Test query mutability.") {
 	CHECK(storage1->count_get_mut == 1);
 	CHECK(storage2->count_get_mut == 0);
 
-	Query<Without<TestAccessMutabilityComponent1>, TestAccessMutabilityComponent2> query_test_without_mut(&world);
+	Query<Not<TestAccessMutabilityComponent1>, TestAccessMutabilityComponent2> query_test_without_mut(&world);
 	query_test_without_mut.begin().operator*(); //Fetch the data.
 
 	CHECK(storage1->count_get_mut == 1);
@@ -933,7 +936,7 @@ TEST_CASE("[Modules][ECS] Test query mutability.") {
 	CHECK(storage1->count_get_immut == 1);
 	CHECK(storage2->count_get_immut == 0);
 
-	Query<Without<const TestAccessMutabilityComponent1>, const TestAccessMutabilityComponent2> query_test_without_immut(&world);
+	Query<Not<const TestAccessMutabilityComponent1>, const TestAccessMutabilityComponent2> query_test_without_immut(&world);
 	query_test_without_immut.begin().operator*(); //Fetch the data.
 
 	CHECK(storage1->count_get_mut == 3);
@@ -1168,7 +1171,7 @@ TEST_CASE("[Modules][ECS] Test static query check query type fetch.") {
 	}
 
 	{
-		Query<Without<TransformComponent>, Maybe<const TagQueryTestComponent>> query(&world);
+		Query<Not<TransformComponent>, Maybe<const TagQueryTestComponent>> query(&world);
 
 		SystemExeInfo info;
 		query.get_components(info);
@@ -1197,7 +1200,7 @@ TEST_CASE("[Modules][ECS] Test static query filter no storage.") {
 	World world;
 
 	{
-		Query<Without<TagQueryTestComponent>, TransformComponent> query(&world);
+		Query<Not<TagQueryTestComponent>, TransformComponent> query(&world);
 
 		// No storage, make sure this returns immediately.
 		CHECK(query.count() == 0);
@@ -1672,7 +1675,7 @@ TEST_CASE("[Modules][ECS] Test static query count.") {
 		CHECK(query.count() == 1);
 	}
 	{
-		Query<const TransformComponent, Without<TagQueryTestComponent>, Without<TestFixedSizeEvent>> query(&world);
+		Query<const TransformComponent, Not<TagQueryTestComponent>, Not<TestFixedSizeEvent>> query(&world);
 		CHECK(query.count() == 1);
 		CHECK(query.has(entity_2));
 	}
@@ -1848,7 +1851,7 @@ TEST_CASE("[Modules][ECS] Test static query Any filter.") {
 	// Test `Any` with `Without` filter.
 	// Note: This test is here just for validation, but doesn't make much sense.
 	{
-		Query<EntityID, Changed<TransformComponent>, Any<Without<TagA>, Without<const TagB>, Without<TagC>>> query(&world);
+		Query<EntityID, Changed<TransformComponent>, Any<Not<TagA>, Not<const TagB>, Not<TagC>>> query(&world);
 
 		// Since `Any` needs just one filter to be satisfied, all are valid.
 		CHECK(query.has(entity_1));
@@ -1861,7 +1864,7 @@ TEST_CASE("[Modules][ECS] Test static query Any filter.") {
 		{
 			auto [entity, transform, tag_a, tag_b, tag_c] = query[entity_1];
 			CHECK(transform != nullptr);
-			CHECK(tag_a == nullptr);
+			CHECK(tag_a != nullptr);
 			CHECK(tag_b == nullptr);
 			CHECK(tag_c == nullptr);
 		}
@@ -1878,7 +1881,7 @@ TEST_CASE("[Modules][ECS] Test static query Any filter.") {
 			auto [entity, transform, tag_a, tag_b, tag_c] = query[entity_3];
 			CHECK(transform != nullptr);
 			CHECK(tag_a == nullptr);
-			CHECK(tag_b == nullptr);
+			CHECK(tag_b != nullptr);
 			CHECK(tag_c == nullptr);
 		}
 
@@ -1887,7 +1890,7 @@ TEST_CASE("[Modules][ECS] Test static query Any filter.") {
 			CHECK(transform != nullptr);
 			CHECK(tag_a == nullptr);
 			CHECK(tag_b == nullptr);
-			CHECK(tag_c == nullptr);
+			CHECK(tag_c != nullptr);
 		}
 
 		for (auto [entity, transform, tag_a, tag_b, tag_c] : query) {
@@ -2035,7 +2038,7 @@ TEST_CASE("[Modules][ECS] Test static query Join filter.") {
 	// Test `Join` with `Without` filter.
 	// Note: This test is here just for validation, but doesn't make much sense.
 	{
-		Query<Changed<TransformComponent>, Join<Without<TagA>, Without<const TagB>, Without<TagC>>> query(&world);
+		Query<Changed<TransformComponent>, Join<Not<TagA>, Not<const TagB>, Not<TagC>>> query(&world);
 
 		// Since `Join` needs just one filter to be satisfied, all are valid.
 		CHECK(query.has(entity_1));

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -1588,6 +1588,7 @@ TEST_CASE("[Modules][ECS] Test static query count.") {
 }
 
 TEST_CASE("[Modules][ECS] Test static query Any filter.") {
+	/* TODO enble this back
 	World world;
 
 	EntityID entity_1 = world
@@ -1754,55 +1755,11 @@ TEST_CASE("[Modules][ECS] Test static query Any filter.") {
 			CHECK(tag.is_null());
 		}
 	}
+	*/
 }
 
-TEST_CASE("[Modules][ECS] Test static query Group filter.") {
-	//World world;
-
-	///*EntityID entity_1 =*/world
-	//		.create_entity()
-	//		.with(TagA())
-	//		.with(TransformComponent());
-
-	///*EntityID entity_2 =*/world
-	//		.create_entity()
-	//		.with(TransformComponent());
-
-	//EntityID entity_3 = world
-	//							.create_entity()
-	//							.with(TagB())
-	//							.with(TransformComponent());
-
-	//EntityID entity_4 = world
-	//							.create_entity()
-	//							.with(TagC())
-	//							.with(TransformComponent());
-
-	//world.get_storage<TagA>()->set_tracing_change(true);
-	//world.get_storage<TagB>()->set_tracing_change(true);
-	//world.get_storage<TagC>()->set_tracing_change(true);
-	//world.get_storage<TransformComponent>()->set_tracing_change(true);
-
-	//world.get_storage<TagC>()->notify_changed(entity_4);
-	//world.get_storage<TransformComponent>()->notify_changed(entity_3);
-
-	//{
-	//	//Query<EntityID, Group<TransformComponent, Any<TagA, TagB, TagC>>> query(&world);
-	//	Query<EntityID, Group<Changed<TransformComponent>, Any<Changed<TagA>, Changed<TagB>, Changed<TagC>>>> query(&world);
-
-	//	auto it = query.begin();
-	//	{
-	//		auto [entity, group] = it.operator*();
-	//		auto [transf, tag] = group;
-	//		CHECK(entity == entity_3);
-	//	}
-
-	//	{
-	//		auto [entity, group] = it.operator*();
-	//		auto [transf, tag] = group;
-	//		CHECK(entity == entity_4);
-	//	}
-	//}
+TEST_CASE("[Modules][ECS] Test static query Join filter.") {
+	// TODO add `Join` tests.
 }
 } // namespace godex_tests
 

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -987,7 +987,7 @@ TEST_CASE("[Modules][ECS] Test DynamicQuery fetch mutability.") {
 	CHECK(storage2->count_get_mut == 0);
 
 	godex::DynamicQuery query_test_without_mut;
-	query_test_without_mut.without_component(TestAccessMutabilityComponent1::get_component_id());
+	query_test_without_mut.not_component(TestAccessMutabilityComponent1::get_component_id());
 	query_test_without_mut.with_component(TestAccessMutabilityComponent2::get_component_id(), true);
 	query_test_without_mut.begin(&world);
 
@@ -1013,7 +1013,7 @@ TEST_CASE("[Modules][ECS] Test DynamicQuery fetch mutability.") {
 
 	CHECK(storage2->count_get_immut == 0);
 	godex::DynamicQuery query_test_without_immut;
-	query_test_without_immut.without_component(TestAccessMutabilityComponent1::get_component_id());
+	query_test_without_immut.not_component(TestAccessMutabilityComponent1::get_component_id());
 	query_test_without_immut.with_component(TestAccessMutabilityComponent2::get_component_id(), false);
 	query_test_without_immut.begin(&world);
 
@@ -1058,7 +1058,7 @@ TEST_CASE("[Modules][ECS] Test DynamicQuery try fetch combination.") {
 		// Check `With`  and `Without`.
 		godex::DynamicQuery query;
 		query.with_component(TestAccessMutabilityComponent1::get_component_id(), false);
-		query.without_component(TestAccessMutabilityComponent2::get_component_id());
+		query.not_component(TestAccessMutabilityComponent2::get_component_id());
 		query.begin(&world);
 		CHECK(query.has(entity_1));
 	}
@@ -1085,7 +1085,7 @@ TEST_CASE("[Modules][ECS] Test DynamicQuery try fetch combination.") {
 	{
 		// Check `Without`.
 		godex::DynamicQuery query;
-		query.without_component(TestAccessMutabilityComponent2::get_component_id());
+		query.not_component(TestAccessMutabilityComponent2::get_component_id());
 		query.begin(&world);
 		// Nothing to fetch, because `Without` alone is meaningless.
 		CHECK(query.is_not_done() == false);
@@ -1095,7 +1095,7 @@ TEST_CASE("[Modules][ECS] Test DynamicQuery try fetch combination.") {
 		// Check `Maybe` and `Without`.
 		godex::DynamicQuery query;
 		query.maybe_component(TestAccessMutabilityComponent1::get_component_id());
-		query.without_component(TestAccessMutabilityComponent2::get_component_id());
+		query.not_component(TestAccessMutabilityComponent2::get_component_id());
 		query.begin(&world);
 		// Nothing to fetch, because `Maybe` and `Without` are meaningless alone.
 		CHECK(query.is_not_done() == false);
@@ -1322,10 +1322,10 @@ TEST_CASE("[Modules][ECS] Test dynamic query") {
 	}
 
 	{
-		// Check the API `without_component()`.
+		// Check the API `not_component()`.
 		godex::DynamicQuery query;
 		query.with_component(TransformComponent::get_component_id());
-		query.without_component(TagQueryTestComponent::get_component_id());
+		query.not_component(TagQueryTestComponent::get_component_id());
 
 		query.begin(&world);
 

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -178,8 +178,12 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 	// Make sure it's possible to compose a tuple and the stored data
 	// can be correctly retrieved.
 	{
-		QueryResultTuple_Impl<0, TagA, TagB> tuple(&a, &b);
+		QueryResultTuple_Impl<0, TagA, TagB> tuple;
+
 		static_assert(tuple.SIZE == 2);
+
+		set<0>(tuple, &a);
+		set<1>(tuple, &b);
 
 		{
 			TagA *ptr_a = get<0>(tuple);
@@ -201,9 +205,13 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 	// all in 1 dimention and can be easily accessed with just 1 structured
 	// bindings as below.
 	{
-		QueryResultTuple_Impl<0, Any<TagA, TagB>, TagC> tuple(&a, &b, &c);
+		QueryResultTuple_Impl<0, Any<TagA, TagB>, TagC> tuple;
 
 		static_assert(tuple.SIZE == 3);
+
+		set<0>(tuple, &a);
+		set<1>(tuple, &b);
+		set<2>(tuple, &c);
 
 		{
 			TagC *ptr_c = get<2>(tuple);
@@ -232,35 +240,21 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 		static_assert(tuple.SIZE == 4);
 
+		set<0>(tuple, &transf);
+		set<1>(tuple, &a);
+		set<2>(tuple, &b);
+		set<3>(tuple, &c);
+
 		{
-			{
-				TransformComponent *transform_ptr = get<0>(tuple);
-				TagA *ptr_a = get<1>(tuple);
-				TagB *ptr_b = get<2>(tuple);
-				TagC *ptr_c = get<3>(tuple);
+			TransformComponent *transform_ptr = get<0>(tuple);
+			TagA *ptr_a = get<1>(tuple);
+			TagB *ptr_b = get<2>(tuple);
+			TagC *ptr_c = get<3>(tuple);
 
-				CHECK(transform_ptr == nullptr);
-				CHECK(ptr_a == nullptr);
-				CHECK(ptr_b == nullptr);
-				CHECK(ptr_c == nullptr);
-			}
-
-			{
-				set<0>(tuple, &transf);
-				set<1>(tuple, &a);
-				set<2>(tuple, &b);
-				set<3>(tuple, &c);
-
-				TransformComponent *transform_ptr = get<0>(tuple);
-				TagA *ptr_a = get<1>(tuple);
-				TagB *ptr_b = get<2>(tuple);
-				TagC *ptr_c = get<3>(tuple);
-
-				CHECK(transform_ptr == &transf);
-				CHECK(ptr_a == &a);
-				CHECK(ptr_b == &b);
-				CHECK(ptr_c == &c);
-			}
+			CHECK(transform_ptr == &transf);
+			CHECK(ptr_a == &a);
+			CHECK(ptr_b == &b);
+			CHECK(ptr_c == &c);
 		}
 
 		transf.transform.origin.x = -50;
@@ -279,7 +273,11 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test other filters
 	{
-		QueryResultTuple_Impl<0, Without<TagA>, Maybe<TagB>, Changed<TagC>> tuple(&a, &b, &c);
+		QueryResultTuple_Impl<0, Without<TagA>, Maybe<TagB>, Changed<TagC>> tuple;
+
+		set<0>(tuple, &a);
+		set<1>(tuple, &b);
+		set<2>(tuple, &c);
 
 		static_assert(tuple.SIZE == 3);
 
@@ -304,7 +302,10 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test `Batch` filter.
 	{
-		QueryResultTuple_Impl<0, Batch<TagA>, Maybe<const TagB>> tuple(Batch(&a, 1), &b);
+		QueryResultTuple_Impl<0, Batch<TagA>, Maybe<const TagB>> tuple;
+
+		set<0>(tuple, Batch(&a, 1));
+		set<1>(tuple, &b);
 
 		static_assert(tuple.SIZE == 2);
 
@@ -328,9 +329,13 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test `EntityID` filter.
 	{
-		QueryResultTuple_Impl<0, Batch<TagA>, EntityID, Maybe<const TagB>> tuple(Batch(&a, 1), EntityID(2), &b);
+		QueryResultTuple_Impl<0, Batch<TagA>, EntityID, Maybe<const TagB>> tuple;
 
 		static_assert(tuple.SIZE == 3);
+
+		set<0>(tuple, Batch(&a, 1));
+		set<1>(tuple, EntityID(2));
+		set<2>(tuple, &b);
 
 		{
 			Batch<TagA *> batch_a = get<0>(tuple);
@@ -370,9 +375,12 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test `Join` filter.
 	{
-		QueryResultTuple_Impl<0, Join<Any<TagA, Changed<TagB>>>, EntityID> tuple(JoinData(&a, TagA::get_component_id(), false), EntityID(5));
+		QueryResultTuple_Impl<0, Join<Any<TagA, Changed<TagB>>>, EntityID> tuple;
 
 		static_assert(tuple.SIZE == 2);
+
+		set<0>(tuple, JoinData(&a, TagA::get_component_id(), false));
+		set<1>(tuple, EntityID(5));
 
 		{
 			JoinData join = get<0>(tuple);

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -639,7 +639,7 @@ TEST_CASE("[Modules][ECS] Test static query deep nesting") {
 		// The `TagC` on the `Entity2` is not changed, so the query fetches it.
 		CHECK(query.has(entity_2));
 
-		auto [entity, tag_a, tag_b, tag_c] = query.new_get(entity_2);
+		auto [entity, tag_a, tag_b, tag_c] = query[entity_2];
 		CHECK(entity == entity_2);
 		CHECK(tag_a != nullptr);
 		CHECK(tag_b != nullptr);
@@ -656,7 +656,7 @@ TEST_CASE("[Modules][ECS] Test static query deep nesting") {
 
 		// In Entity1 the tag is changed, we expect it.
 		{
-			auto [entity, tag_a, tag_c] = query.new_get(entity_1);
+			auto [entity, tag_a, tag_c] = query[entity_1];
 			CHECK(entity == entity_1);
 			CHECK(tag_a != nullptr);
 			CHECK(tag_c != nullptr);
@@ -664,10 +664,22 @@ TEST_CASE("[Modules][ECS] Test static query deep nesting") {
 
 		// In Entity2 the tag is NOT changed, we expect nullptr.
 		{
-			auto [entity, tag_a, tag_c] = query.new_get(entity_2);
+			auto [entity, tag_a, tag_c] = query[entity_2];
 			CHECK(entity == entity_2);
 			CHECK(tag_a != nullptr);
 			CHECK(tag_c == nullptr);
+		}
+
+		// Fetch using the for loop.
+		for (auto [entity, tag_a, tag_c] : query) {
+			if (entity == entity_1) {
+				CHECK(tag_a != nullptr);
+				CHECK(tag_c != nullptr);
+			} else {
+				CHECK(entity == entity_2);
+				CHECK(tag_a != nullptr);
+				CHECK(tag_c == nullptr);
+			}
 		}
 	}
 
@@ -677,10 +689,11 @@ TEST_CASE("[Modules][ECS] Test static query deep nesting") {
 
 		CHECK(query.has(entity_1));
 		CHECK(query.has(entity_2));
+		CHECK(query.count() == 2);
 
 		// In Entity1 the event is NOT changed, we expect nullptr.
 		{
-			auto [entity, transf, event] = query.new_get(entity_1);
+			auto [entity, transf, event] = query[entity_1];
 			CHECK(entity == entity_1);
 			CHECK(transf != nullptr);
 			CHECK(event.is_empty());
@@ -688,13 +701,26 @@ TEST_CASE("[Modules][ECS] Test static query deep nesting") {
 
 		// In Entity2 the tag is NOT changed, we expect nullptr.
 		{
-			auto [entity, transf, event] = query.new_get(entity_2);
+			auto [entity, transf, event] = query[entity_2];
 			CHECK(entity == entity_2);
 			CHECK(transf != nullptr);
 			CHECK(event.is_empty() == false);
 			CHECK(event.get_size() == 2);
 			CHECK(event[0]->number == 25);
 			CHECK(event[1]->number == 30);
+		}
+
+		// Fetch using the for loop.
+		for (auto [entity, transf, event] : query) {
+			CHECK((entity == entity_1 || entity == entity_2));
+			CHECK(transf != nullptr);
+			if (entity == entity_1) {
+				CHECK(event.is_empty());
+			} else {
+				CHECK(event.get_size() == 2);
+				CHECK(event[0]->number == 25);
+				CHECK(event[1]->number == 30);
+			}
 		}
 	}
 

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -178,7 +178,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 	// Make sure it's possible to compose a tuple and the stored data
 	// can be correctly retrieved.
 	{
-		QueryResultTuple_Impl<0, TagA, TagB> tuple;
+		QueryResultTuple<TagA, TagB> tuple;
 
 		static_assert(tuple.SIZE == 2);
 
@@ -205,7 +205,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 	// all in 1 dimention and can be easily accessed with just 1 structured
 	// bindings as below.
 	{
-		QueryResultTuple_Impl<0, Any<TagA, TagB>, TagC> tuple;
+		QueryResultTuple<Any<TagA, TagB>, TagC> tuple;
 
 		static_assert(tuple.SIZE == 3);
 
@@ -236,7 +236,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 	{
 		TransformComponent transf;
 
-		QueryResultTuple_Impl<0, TransformComponent, Any<TagA, TagB>, TagC> tuple;
+		QueryResultTuple<TransformComponent, Any<TagA, TagB>, TagC> tuple;
 
 		static_assert(tuple.SIZE == 4);
 
@@ -273,7 +273,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test other filters
 	{
-		QueryResultTuple_Impl<0, Without<TagA>, Maybe<TagB>, Changed<TagC>> tuple;
+		QueryResultTuple<Without<TagA>, Maybe<TagB>, Changed<TagC>> tuple;
 
 		set<0>(tuple, &a);
 		set<1>(tuple, &b);
@@ -302,7 +302,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test `Batch` filter.
 	{
-		QueryResultTuple_Impl<0, Batch<TagA>, Maybe<const TagB>> tuple;
+		QueryResultTuple<Batch<TagA>, Maybe<const TagB>> tuple;
 
 		set<0>(tuple, Batch(&a, 1));
 		set<1>(tuple, &b);
@@ -329,7 +329,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test `EntityID` filter.
 	{
-		QueryResultTuple_Impl<0, Batch<TagA>, EntityID, Maybe<const TagB>> tuple;
+		QueryResultTuple<Batch<TagA>, EntityID, Maybe<const TagB>> tuple;
 
 		static_assert(tuple.SIZE == 3);
 
@@ -375,7 +375,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test `Join` filter.
 	{
-		QueryResultTuple_Impl<0, Join<Any<TagA, Changed<TagB>>>, EntityID> tuple;
+		QueryResultTuple<Join<Any<TagA, Changed<TagB>>>, EntityID> tuple;
 
 		static_assert(tuple.SIZE == 2);
 
@@ -416,7 +416,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test deep all filters.
 	{
-		QueryResultTuple_Impl<0, EntityID, Any<Maybe<Changed<TagC>>, Batch<Maybe<Changed<TagB>>>>, Join<Any<Without<TagA>, Changed<TagB>>>> tuple;
+		QueryResultTuple<EntityID, Any<Maybe<Changed<TagC>>, Batch<Maybe<Changed<TagB>>>>, Join<Any<Without<TagA>, Changed<TagB>>>> tuple;
 
 		static_assert(tuple.SIZE == 4);
 
@@ -453,7 +453,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 
 	// Test multiple nested Any filters.
 	{
-		QueryResultTuple_Impl<0,
+		QueryResultTuple<
 				EntityID,
 				Any<
 						Maybe<Changed<TagC>>,

--- a/world/world.h
+++ b/world/world.h
@@ -1,9 +1,5 @@
 #pragma once
 
-/**
-	@author AndreaCatania
-*/
-
 #include "../databags/databag.h"
 #include "../ecs_types.h"
 #include "../storage/storage.h"


### PR DESCRIPTION
- Refactored the `Query` mechanics, so it's now possible to combine the filters for fine-grained result!
- Removed `Without` filter in favor of `Not`.
- Now the `Query` return a `QueryResultTuple` (before it was returning `std::tuple`).
- Add `QueryResultTuple` for a great control over the query unpacking mechanism.
- Refactored the `Any` filter: Now it returns all the `Components` if one filter is satisfied.
- Add `Join` filter: Collapse many components to one.
- Refactored all the Filters to allow nesting.

```c++
// Take all entities with transform component
Query<Transform> query;
for( auto [ transform ] : query ) {}


// Take the entities Position, Rotation and Scale, if one of those change.
Query<Any<Changed<Position>, Changed<Rotation>, Changed<Scale>>> query;
for( auto [ position, rotation, scale ] : query ) {}


// Take the enemies and its team.
Query<Enemy, Join<TeamA, TeamB, TeamC>> query;
for( auto [ enemy, team ] : query ) {}


// Take the enemies whom name OR team changed
Query<Enemy, Any<Changed<Name>, Join<Changed<TeamA>, Changed<TeamB>, Changed<TeamC>>> query;
for( auto [ enemy, name, team ] : query ) {}


// Take the player, if its health doesn't changed.
Query<Player, Not<Changed<Health>>> query;
for( auto [ player, health ] : query ) {}


// Take the Speedups assigned to the character if changed.
Query<Character, Batch<Changed<Speedup>>> query;
for( auto [ charcter, speedups ] : query ) {}


// Take all the EntityID for the crates.
Query<EntityID, Crate> query;
for( auto [ entity, crate ] : query ) {}
```

