### PR TITLE
[Breaking change] Improved scene storage mechanism + Fixes

### DIFF
--- a/modules/bullet_physics/bt_systems.cpp
+++ b/modules/bullet_physics/bt_systems.cpp
@@ -19,14 +19,14 @@ void bt_body_config(
 				Any<Changed<BtRigidBody>,
 						Changed<BtSpaceMarker>,
 						Join<
-								Changed<BtShapeBox>,
-								Changed<BtShapeSphere>,
-								Changed<BtShapeCapsule>,
-								Changed<BtShapeCone>,
-								Changed<BtShapeCylinder>,
-								Changed<BtShapeWorldMargin>,
-								Changed<BtShapeConvex>,
-								Changed<BtShapeTrimesh>>>,
+								Changed<BtBox>,
+								Changed<BtSphere>,
+								Changed<BtCapsule>,
+								Changed<BtCone>,
+								Changed<BtCylinder>,
+								Changed<BtWorldMargin>,
+								Changed<BtConvex>,
+								Changed<BtTrimesh>>>,
 				Maybe<TransformComponent>> &p_query) {
 	for (auto [entity, body, space_marker, shape_container, transform] : p_query) {
 		if (body == nullptr) {
@@ -129,14 +129,14 @@ void bt_area_config(
 				Any<Changed<BtArea>,
 						Changed<BtSpaceMarker>,
 						Join<
-								Changed<BtShapeBox>,
-								Changed<BtShapeSphere>,
-								Changed<BtShapeCapsule>,
-								Changed<BtShapeCone>,
-								Changed<BtShapeCylinder>,
-								Changed<BtShapeWorldMargin>,
-								Changed<BtShapeConvex>,
-								Changed<BtShapeTrimesh>>>,
+								Changed<BtBox>,
+								Changed<BtSphere>,
+								Changed<BtCapsule>,
+								Changed<BtCone>,
+								Changed<BtCylinder>,
+								Changed<BtWorldMargin>,
+								Changed<BtConvex>,
+								Changed<BtTrimesh>>>,
 				Maybe<TransformComponent>> &p_query) {
 	for (auto [entity, area, space_marker, shape_container, transform] : p_query) {
 		if (area == nullptr) {
@@ -261,7 +261,7 @@ void bt_spaces_step(
 		const FrameTime *p_iterator_info,
 		// TODO this is not used, though we need it just to be sure they are not
 		// touched by anything else.
-		Query<BtRigidBody, BtArea, BtShapeBox, BtShapeSphere, BtShapeCapsule, BtShapeCone, BtShapeCylinder, BtShapeWorldMargin, BtShapeConvex, BtShapeTrimesh> &p_query) {
+		Query<BtRigidBody, BtArea, BtBox, BtSphere, BtCapsule, BtCone, BtCylinder, BtWorldMargin, BtConvex, BtTrimesh> &p_query) {
 	const real_t physics_delta = p_iterator_info->get_physics_delta();
 
 	// TODO consider to create a system for each space? So it has much more control.

--- a/modules/bullet_physics/bt_systems.cpp
+++ b/modules/bullet_physics/bt_systems.cpp
@@ -28,7 +28,7 @@ void bt_body_config(
 								Changed<BtConvex>,
 								Changed<BtTrimesh>>>,
 				Maybe<TransformComponent>> &p_query) {
-	for (auto [entity, body, space_marker, shape_container, transform] : p_query) {
+	for (auto [entity, body, space_marker, shape_container, transform] : p_query.space(GLOBAL)) {
 		if (body == nullptr) {
 			// Body not yet assigned to this Entity, skip.
 			continue;
@@ -138,7 +138,7 @@ void bt_area_config(
 								Changed<BtConvex>,
 								Changed<BtTrimesh>>>,
 				Maybe<TransformComponent>> &p_query) {
-	for (auto [entity, area, space_marker, shape_container, transform] : p_query) {
+	for (auto [entity, area, space_marker, shape_container, transform] : p_query.space(GLOBAL)) {
 		if (area == nullptr) {
 			// Body not yet assigned to this Entity, skip.
 			continue;

--- a/modules/bullet_physics/bt_systems.h
+++ b/modules/bullet_physics/bt_systems.h
@@ -22,14 +22,14 @@ void bt_body_config(
 				Any<Changed<BtRigidBody>,
 						Changed<BtSpaceMarker>,
 						Join<
-								Changed<BtShapeBox>,
-								Changed<BtShapeSphere>,
-								Changed<BtShapeCapsule>,
-								Changed<BtShapeCone>,
-								Changed<BtShapeCylinder>,
-								Changed<BtShapeWorldMargin>,
-								Changed<BtShapeConvex>,
-								Changed<BtShapeTrimesh>>>,
+								Changed<BtBox>,
+								Changed<BtSphere>,
+								Changed<BtCapsule>,
+								Changed<BtCone>,
+								Changed<BtCylinder>,
+								Changed<BtWorldMargin>,
+								Changed<BtConvex>,
+								Changed<BtTrimesh>>>,
 				Maybe<TransformComponent>> &p_query);
 
 /// Configures the Area
@@ -46,14 +46,14 @@ void bt_area_config(
 				Any<Changed<BtArea>,
 						Changed<BtSpaceMarker>,
 						Join<
-								Changed<BtShapeBox>,
-								Changed<BtShapeSphere>,
-								Changed<BtShapeCapsule>,
-								Changed<BtShapeCone>,
-								Changed<BtShapeCylinder>,
-								Changed<BtShapeWorldMargin>,
-								Changed<BtShapeConvex>,
-								Changed<BtShapeTrimesh>>>,
+								Changed<BtBox>,
+								Changed<BtSphere>,
+								Changed<BtCapsule>,
+								Changed<BtCone>,
+								Changed<BtCylinder>,
+								Changed<BtWorldMargin>,
+								Changed<BtConvex>,
+								Changed<BtTrimesh>>>,
 				Maybe<TransformComponent>> &p_query);
 
 void bt_apply_forces(
@@ -73,7 +73,7 @@ void bt_spaces_step(
 		const FrameTime *p_iterator_info,
 		// TODO this is not used, though we need it just to be sure they are not
 		// touched by anything else.
-		Query<BtRigidBody, BtArea, BtShapeBox, BtShapeSphere, BtShapeCapsule, BtShapeCone, BtShapeCylinder, BtShapeWorldMargin, BtShapeConvex, BtShapeTrimesh> &p_query);
+		Query<BtRigidBody, BtArea, BtBox, BtSphere, BtCapsule, BtCone, BtCylinder, BtWorldMargin, BtConvex, BtTrimesh> &p_query);
 
 /// Perform the Areas overlap check.
 void bt_overlap_check(

--- a/modules/bullet_physics/components_gizmos.cpp
+++ b/modules/bullet_physics/components_gizmos.cpp
@@ -3,7 +3,7 @@
 #include "../godot/nodes/entity.h"
 #include "debug_utilities.h"
 
-void BtShapeBoxGizmo::init() {
+void BtBoxGizmo::init() {
 	const Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
 
@@ -14,7 +14,7 @@ void BtShapeBoxGizmo::init() {
 	create_handle_material("handles");
 }
 
-void BtShapeBoxGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
+void BtBoxGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 
@@ -51,7 +51,7 @@ void BtShapeBoxGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 }
 
-int BtShapeBoxGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
+int BtBoxGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, 0);
 
@@ -62,7 +62,7 @@ int BtShapeBoxGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
 	return 0;
 }
 
-String BtShapeBoxGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
+String BtBoxGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	if (p_idx == 0) {
 		return "half_extents_x";
 	} else if (p_idx == 1) {
@@ -72,7 +72,7 @@ String BtShapeBoxGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_
 	}
 }
 
-Variant BtShapeBoxGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
+Variant BtBoxGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, Variant());
 	ERR_FAIL_COND_V(entity->has_component(box_component_name) == false, Variant());
@@ -82,7 +82,7 @@ Variant BtShapeBoxGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx)
 	return half_extents[p_idx];
 }
 
-void BtShapeBoxGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
+void BtBoxGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(box_component_name) == false);
@@ -114,7 +114,7 @@ void BtShapeBoxGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D
 	entity->set_component_value(box_component_name, half_extents_name, half_extents);
 }
 
-void BtShapeBoxGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
+void BtBoxGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(box_component_name) == false);
@@ -132,12 +132,12 @@ void BtShapeBoxGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const
 	}
 }
 
-void BtShapeSphereGizmo::init() {
+void BtSphereGizmo::init() {
 	// No need to register the materials, everything we need is already
 	// registered by the box gizmo.
 }
 
-void BtShapeSphereGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
+void BtSphereGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 
@@ -188,7 +188,7 @@ void BtShapeSphereGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 }
 
-int BtShapeSphereGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
+int BtSphereGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, 0);
 
@@ -199,11 +199,11 @@ int BtShapeSphereGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const
 	return 0;
 }
 
-String BtShapeSphereGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
+String BtSphereGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	return "radius";
 }
 
-Variant BtShapeSphereGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
+Variant BtSphereGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, Variant());
 	ERR_FAIL_COND_V(entity->has_component(sphere_component_name) == false, Variant());
@@ -211,7 +211,7 @@ Variant BtShapeSphereGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_i
 	return entity->get_component_value(sphere_component_name, radius_name);
 }
 
-void BtShapeSphereGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
+void BtSphereGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(sphere_component_name) == false);
@@ -238,7 +238,7 @@ void BtShapeSphereGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camer
 	entity->set_component_value(sphere_component_name, radius_name, d);
 }
 
-void BtShapeSphereGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
+void BtSphereGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(sphere_component_name) == false);
@@ -256,12 +256,12 @@ void BtShapeSphereGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, co
 	}
 }
 
-void BtShapeCapsuleGizmo::init() {
+void BtCapsuleGizmo::init() {
 	// No need to register the materials, everything we need is already
 	// registered by the box gizmo.
 }
 
-void BtShapeCapsuleGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
+void BtCapsuleGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 
@@ -339,7 +339,7 @@ void BtShapeCapsuleGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 }
 
-int BtShapeCapsuleGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
+int BtCapsuleGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, 0);
 
@@ -350,7 +350,7 @@ int BtShapeCapsuleGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) cons
 	return 0;
 }
 
-String BtShapeCapsuleGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
+String BtCapsuleGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	if (p_idx == 0) {
 		return "radius";
 	} else {
@@ -358,7 +358,7 @@ String BtShapeCapsuleGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, in
 	}
 }
 
-Variant BtShapeCapsuleGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
+Variant BtCapsuleGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, Variant());
 	ERR_FAIL_COND_V(entity->has_component(capsule_component_name) == false, Variant());
@@ -370,7 +370,7 @@ Variant BtShapeCapsuleGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_
 	}
 }
 
-void BtShapeCapsuleGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
+void BtCapsuleGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(capsule_component_name) == false);
@@ -408,7 +408,7 @@ void BtShapeCapsuleGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Came
 	}
 }
 
-void BtShapeCapsuleGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
+void BtCapsuleGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(capsule_component_name) == false);
@@ -426,12 +426,12 @@ void BtShapeCapsuleGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, c
 	}
 }
 
-void BtShapeConeGizmo::init() {
+void BtConeGizmo::init() {
 	// No need to register the materials, everything we need is already
 	// registered by the box gizmo.
 }
 
-void BtShapeConeGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
+void BtConeGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 
@@ -489,7 +489,7 @@ void BtShapeConeGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 }
 
-int BtShapeConeGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
+int BtConeGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, 0);
 
@@ -500,7 +500,7 @@ int BtShapeConeGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
 	return 0;
 }
 
-String BtShapeConeGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
+String BtConeGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	if (p_idx == 0) {
 		return "radius";
 	} else {
@@ -508,7 +508,7 @@ String BtShapeConeGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p
 	}
 }
 
-Variant BtShapeConeGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
+Variant BtConeGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, Variant());
 	ERR_FAIL_COND_V(entity->has_component(cone_component_name) == false, Variant());
@@ -520,7 +520,7 @@ Variant BtShapeConeGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx
 	}
 }
 
-void BtShapeConeGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
+void BtConeGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(cone_component_name) == false);
@@ -554,7 +554,7 @@ void BtShapeConeGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3
 	}
 }
 
-void BtShapeConeGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
+void BtConeGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(cone_component_name) == false);
@@ -572,12 +572,12 @@ void BtShapeConeGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, cons
 	}
 }
 
-void BtShapeCylinderGizmo::init() {
+void BtCylinderGizmo::init() {
 	// No need to register the materials, everything we need is already
 	// registered by the box gizmo.
 }
 
-void BtShapeCylinderGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
+void BtCylinderGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 
@@ -653,7 +653,7 @@ void BtShapeCylinderGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 }
 
-int BtShapeCylinderGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
+int BtCylinderGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, 0);
 
@@ -664,7 +664,7 @@ int BtShapeCylinderGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) con
 	return 0;
 }
 
-String BtShapeCylinderGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
+String BtCylinderGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	if (p_idx == 0) {
 		return "radius";
 	} else {
@@ -672,7 +672,7 @@ String BtShapeCylinderGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, i
 	}
 }
 
-Variant BtShapeCylinderGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
+Variant BtCylinderGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND_V(entity == nullptr, Variant());
 	ERR_FAIL_COND_V(entity->has_component(cylinder_component_name) == false, Variant());
@@ -684,7 +684,7 @@ Variant BtShapeCylinderGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p
 	}
 }
 
-void BtShapeCylinderGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
+void BtCylinderGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(cylinder_component_name) == false);
@@ -717,7 +717,7 @@ void BtShapeCylinderGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Cam
 	}
 }
 
-void BtShapeCylinderGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
+void BtCylinderGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 	ERR_FAIL_COND(entity->has_component(cylinder_component_name) == false);
@@ -741,12 +741,12 @@ public:
 	Ref<ArrayMesh> mesh;
 };
 
-void BtShapeConvexGizmo::init() {
+void BtConvexGizmo::init() {
 	// No need to register the materials, everything we need is already
 	// registered by the box gizmo.
 }
 
-void BtShapeConvexGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
+void BtConvexGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 
@@ -775,30 +775,30 @@ void BtShapeConvexGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 }
 
-int BtShapeConvexGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
+int BtConvexGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
 	return 0;
 }
 
-String BtShapeConvexGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
+String BtConvexGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	return "";
 }
 
-Variant BtShapeConvexGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
+Variant BtConvexGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	return Variant();
 }
 
-void BtShapeConvexGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
+void BtConvexGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
 }
 
-void BtShapeConvexGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
+void BtConvexGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
 }
 
-void BtShapeTrimeshGizmo::init() {
+void BtTrimeshGizmo::init() {
 	// No need to register the materials, everything we need is already
 	// registered by the box gizmo.
 }
 
-void BtShapeTrimeshGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
+void BtTrimeshGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	Entity3D *entity = static_cast<Entity3D *>(p_gizmo->get_spatial_node());
 	ERR_FAIL_COND(entity == nullptr);
 
@@ -827,20 +827,20 @@ void BtShapeTrimeshGizmo::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 }
 
-int BtShapeTrimeshGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
+int BtTrimeshGizmo::get_handle_count(const EditorNode3DGizmo *p_gizmo) const {
 	return 0;
 }
 
-String BtShapeTrimeshGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
+String BtTrimeshGizmo::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	return "";
 }
 
-Variant BtShapeTrimeshGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
+Variant BtTrimeshGizmo::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
 	return Variant();
 }
 
-void BtShapeTrimeshGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
+void BtTrimeshGizmo::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
 }
 
-void BtShapeTrimeshGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
+void BtTrimeshGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
 }

--- a/modules/bullet_physics/components_gizmos.h
+++ b/modules/bullet_physics/components_gizmos.h
@@ -2,8 +2,8 @@
 
 #include "../godot/editor_plugins/components_gizmo_3d.h"
 
-class BtShapeBoxGizmo : public ComponentGizmo {
-	StringName box_component_name = "BtShapeBox";
+class BtBoxGizmo : public ComponentGizmo {
+	StringName box_component_name = "BtBox";
 	StringName half_extents_name = "half_extents";
 
 public:
@@ -16,8 +16,8 @@ public:
 	virtual void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
 };
 
-class BtShapeSphereGizmo : public ComponentGizmo {
-	StringName sphere_component_name = "BtShapeSphere";
+class BtSphereGizmo : public ComponentGizmo {
+	StringName sphere_component_name = "BtSphere";
 	StringName radius_name = "radius";
 
 public:
@@ -30,23 +30,8 @@ public:
 	virtual void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
 };
 
-class BtShapeCapsuleGizmo : public ComponentGizmo {
-	StringName capsule_component_name = "BtShapeCapsule";
-	StringName radius_name = "radius";
-	StringName height_name = "height";
-
-public:
-	virtual void init() override;
-	virtual void redraw(EditorNode3DGizmo *p_gizmo) override;
-	virtual int get_handle_count(const EditorNode3DGizmo *p_gizmo) const override;
-	virtual String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	virtual Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	virtual void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	virtual void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
-};
-
-class BtShapeConeGizmo : public ComponentGizmo {
-	StringName cone_component_name = "BtShapeCone";
+class BtCapsuleGizmo : public ComponentGizmo {
+	StringName capsule_component_name = "BtCapsule";
 	StringName radius_name = "radius";
 	StringName height_name = "height";
 
@@ -60,8 +45,8 @@ public:
 	virtual void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
 };
 
-class BtShapeCylinderGizmo : public ComponentGizmo {
-	StringName cylinder_component_name = "BtShapeCylinder";
+class BtConeGizmo : public ComponentGizmo {
+	StringName cone_component_name = "BtCone";
 	StringName radius_name = "radius";
 	StringName height_name = "height";
 
@@ -75,8 +60,23 @@ public:
 	virtual void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
 };
 
-class BtShapeConvexGizmo : public ComponentGizmo {
-	StringName convex_component_name = "BtShapeConvex";
+class BtCylinderGizmo : public ComponentGizmo {
+	StringName cylinder_component_name = "BtCylinder";
+	StringName radius_name = "radius";
+	StringName height_name = "height";
+
+public:
+	virtual void init() override;
+	virtual void redraw(EditorNode3DGizmo *p_gizmo) override;
+	virtual int get_handle_count(const EditorNode3DGizmo *p_gizmo) const override;
+	virtual String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
+	virtual Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
+	virtual void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
+	virtual void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+};
+
+class BtConvexGizmo : public ComponentGizmo {
+	StringName convex_component_name = "BtConvex";
 	StringName points_name = "points";
 
 public:
@@ -89,8 +89,8 @@ public:
 	virtual void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
 };
 
-class BtShapeTrimeshGizmo : public ComponentGizmo {
-	StringName trimesh_component_name = "BtShapeTrimesh";
+class BtTrimeshGizmo : public ComponentGizmo {
+	StringName trimesh_component_name = "BtTrimesh";
 	StringName faces_name = "faces";
 
 public:

--- a/modules/bullet_physics/components_rigid_shape.cpp
+++ b/modules/bullet_physics/components_rigid_shape.cpp
@@ -7,21 +7,21 @@
 btCollisionShape *BtRigidShape::get_shape() {
 	switch (type) {
 		case TYPE_BOX:
-			return &static_cast<BtShapeBox *>(this)->box;
+			return &static_cast<BtBox *>(this)->box;
 		case TYPE_SPHERE:
-			return &static_cast<BtShapeSphere *>(this)->sphere;
+			return &static_cast<BtSphere *>(this)->sphere;
 		case TYPE_CAPSULE:
-			return &static_cast<BtShapeCapsule *>(this)->capsule;
+			return &static_cast<BtCapsule *>(this)->capsule;
 		case TYPE_CONE:
-			return &static_cast<BtShapeCone *>(this)->cone;
+			return &static_cast<BtCone *>(this)->cone;
 		case TYPE_CYLINDER:
-			return &static_cast<BtShapeCylinder *>(this)->cylinder;
+			return &static_cast<BtCylinder *>(this)->cylinder;
 		case TYPE_WORLD_MARGIN:
-			return &static_cast<BtShapeWorldMargin *>(this)->world_margin;
+			return &static_cast<BtWorldMargin *>(this)->world_margin;
 		case TYPE_CONVEX:
-			return &static_cast<BtShapeConvex *>(this)->convex;
+			return &static_cast<BtConvex *>(this)->convex;
 		case TYPE_TRIMESH:
-			return static_cast<BtShapeTrimesh *>(this)->trimesh;
+			return static_cast<BtTrimesh *>(this)->trimesh;
 	}
 
 	CRASH_NOW_MSG("Please support all shapes.");
@@ -32,169 +32,169 @@ const btCollisionShape *BtRigidShape::get_shape() const {
 	return const_cast<BtRigidShape *>(this)->get_shape();
 }
 
-void BtShapeBox::_bind_methods() {
-	ECS_BIND_PROPERTY_FUNC(BtShapeBox, PropertyInfo(Variant::VECTOR3, "half_extents"), set_half_extents, get_half_extents);
-	ECS_BIND_PROPERTY_FUNC(BtShapeBox, PropertyInfo(Variant::FLOAT, "margin"), set_margin, get_margin);
+void BtBox::_bind_methods() {
+	ECS_BIND_PROPERTY_FUNC(BtBox, PropertyInfo(Variant::VECTOR3, "half_extents"), set_half_extents, get_half_extents);
+	ECS_BIND_PROPERTY_FUNC(BtBox, PropertyInfo(Variant::FLOAT, "margin"), set_margin, get_margin);
 }
 
-void BtShapeBox::_get_storage_config(Dictionary &r_config) {
+void BtBox::_get_storage_config(Dictionary &r_config) {
 	/// Configure the storage of this component to have pages of 500 Physis Bodies
 	/// You can tweak this in editor.
 	r_config["page_size"] = 200;
 }
 
-void BtShapeBox::set_half_extents(const Vector3 &p_half_extends) {
+void BtBox::set_half_extents(const Vector3 &p_half_extends) {
 	box.setImplicitShapeDimensions(btVector3(p_half_extends.x - box.getMargin(), p_half_extends.y - box.getMargin(), p_half_extends.z - box.getMargin()));
 }
 
-Vector3 BtShapeBox::get_half_extents() const {
+Vector3 BtBox::get_half_extents() const {
 	const btVector3 &extents = box.getImplicitShapeDimensions();
 	return Vector3(extents.x() + box.getMargin(), extents.y() + box.getMargin(), extents.z() + box.getMargin());
 }
 
-void BtShapeBox::set_margin(real_t p_margin) {
+void BtBox::set_margin(real_t p_margin) {
 	box.setMargin(p_margin);
 }
 
-real_t BtShapeBox::get_margin() const {
+real_t BtBox::get_margin() const {
 	return box.getMargin();
 }
 
-void BtShapeSphere::_bind_methods() {
-	ECS_BIND_PROPERTY_FUNC(BtShapeSphere, PropertyInfo(Variant::FLOAT, "radius"), set_radius, get_radius);
+void BtSphere::_bind_methods() {
+	ECS_BIND_PROPERTY_FUNC(BtSphere, PropertyInfo(Variant::FLOAT, "radius"), set_radius, get_radius);
 }
 
-void BtShapeSphere::_get_storage_config(Dictionary &r_config) {
+void BtSphere::_get_storage_config(Dictionary &r_config) {
 	/// Configure the storage of this component to have pages of 500 Physis Bodies
 	/// You can tweak this in editor.
 	r_config["page_size"] = 50;
 }
 
-void BtShapeSphere::set_radius(real_t p_radius) {
+void BtSphere::set_radius(real_t p_radius) {
 	sphere.setUnscaledRadius(p_radius);
 }
 
-real_t BtShapeSphere::get_radius() const {
+real_t BtSphere::get_radius() const {
 	return sphere.getRadius();
 }
 
-void BtShapeCapsule::_bind_methods() {
-	ECS_BIND_PROPERTY_FUNC(BtShapeCapsule, PropertyInfo(Variant::FLOAT, "radius"), set_radius, get_radius);
-	ECS_BIND_PROPERTY_FUNC(BtShapeCapsule, PropertyInfo(Variant::FLOAT, "height"), set_height, get_height);
+void BtCapsule::_bind_methods() {
+	ECS_BIND_PROPERTY_FUNC(BtCapsule, PropertyInfo(Variant::FLOAT, "radius"), set_radius, get_radius);
+	ECS_BIND_PROPERTY_FUNC(BtCapsule, PropertyInfo(Variant::FLOAT, "height"), set_height, get_height);
 }
 
-void BtShapeCapsule::_get_storage_config(Dictionary &r_config) {
+void BtCapsule::_get_storage_config(Dictionary &r_config) {
 	/// Configure the storage of this component to have pages of 500 Physis Bodies
 	/// You can tweak this in editor.
 	r_config["page_size"] = 50;
 }
 
-void BtShapeCapsule::set_radius(real_t p_radius) {
+void BtCapsule::set_radius(real_t p_radius) {
 	// The capsule margin is the radius of the capsule.
 	capsule.setMargin(p_radius);
 	capsule.setImplicitShapeDimensions(btVector3(p_radius, capsule.getHalfHeight(), p_radius));
 }
 
-real_t BtShapeCapsule::get_radius() const {
+real_t BtCapsule::get_radius() const {
 	return capsule.getRadius();
 }
 
-void BtShapeCapsule::set_height(real_t p_height) {
+void BtCapsule::set_height(real_t p_height) {
 	capsule.setImplicitShapeDimensions(btVector3(capsule.getRadius(), 0.5f * p_height, capsule.getRadius()));
 }
 
-real_t BtShapeCapsule::get_height() const {
+real_t BtCapsule::get_height() const {
 	return capsule.getHalfHeight() * 2.0;
 }
 
-void BtShapeCone::_bind_methods() {
-	ECS_BIND_PROPERTY_FUNC(BtShapeCone, PropertyInfo(Variant::FLOAT, "radius"), set_radius, get_radius);
-	ECS_BIND_PROPERTY_FUNC(BtShapeCone, PropertyInfo(Variant::FLOAT, "height"), set_height, get_height);
-	ECS_BIND_PROPERTY_FUNC(BtShapeCone, PropertyInfo(Variant::FLOAT, "margin"), set_margin, get_margin);
+void BtCone::_bind_methods() {
+	ECS_BIND_PROPERTY_FUNC(BtCone, PropertyInfo(Variant::FLOAT, "radius"), set_radius, get_radius);
+	ECS_BIND_PROPERTY_FUNC(BtCone, PropertyInfo(Variant::FLOAT, "height"), set_height, get_height);
+	ECS_BIND_PROPERTY_FUNC(BtCone, PropertyInfo(Variant::FLOAT, "margin"), set_margin, get_margin);
 }
 
-void BtShapeCone::_get_storage_config(Dictionary &r_config) {
+void BtCone::_get_storage_config(Dictionary &r_config) {
 	/// Configure the storage of this component to have pages of 500 Physis Bodies
 	/// You can tweak this in editor.
 	r_config["page_size"] = 50;
 }
 
-void BtShapeCone::set_radius(real_t p_radius) {
+void BtCone::set_radius(real_t p_radius) {
 	cone.setRadius(p_radius);
 }
 
-real_t BtShapeCone::get_radius() const {
+real_t BtCone::get_radius() const {
 	return cone.getRadius();
 }
 
-void BtShapeCone::set_height(real_t p_height) {
+void BtCone::set_height(real_t p_height) {
 	cone.setHeight(p_height);
 }
 
-real_t BtShapeCone::get_height() const {
+real_t BtCone::get_height() const {
 	return cone.getHeight();
 }
 
-void BtShapeCone::set_margin(real_t p_margin) {
+void BtCone::set_margin(real_t p_margin) {
 	cone.setMargin(p_margin);
 }
 
-real_t BtShapeCone::get_margin() const {
+real_t BtCone::get_margin() const {
 	return cone.getMargin();
 }
 
-void BtShapeCylinder::_bind_methods() {
-	ECS_BIND_PROPERTY_FUNC(BtShapeCylinder, PropertyInfo(Variant::FLOAT, "radius"), set_radius, get_radius);
-	ECS_BIND_PROPERTY_FUNC(BtShapeCylinder, PropertyInfo(Variant::FLOAT, "height"), set_height, get_height);
-	ECS_BIND_PROPERTY_FUNC(BtShapeCylinder, PropertyInfo(Variant::FLOAT, "margin"), set_margin, get_margin);
+void BtCylinder::_bind_methods() {
+	ECS_BIND_PROPERTY_FUNC(BtCylinder, PropertyInfo(Variant::FLOAT, "radius"), set_radius, get_radius);
+	ECS_BIND_PROPERTY_FUNC(BtCylinder, PropertyInfo(Variant::FLOAT, "height"), set_height, get_height);
+	ECS_BIND_PROPERTY_FUNC(BtCylinder, PropertyInfo(Variant::FLOAT, "margin"), set_margin, get_margin);
 }
 
-void BtShapeCylinder::_get_storage_config(Dictionary &r_config) {
+void BtCylinder::_get_storage_config(Dictionary &r_config) {
 	/// Configure the storage of this component to have pages of 500 Physis Bodies
 	/// You can tweak this in editor.
 	r_config["page_size"] = 50;
 }
 
-void BtShapeCylinder::set_radius(real_t p_radius) {
+void BtCylinder::set_radius(real_t p_radius) {
 	cylinder.setImplicitShapeDimensions(btVector3(p_radius - get_margin(), (get_height() * 0.5) - get_margin(), p_radius - get_margin()));
 }
 
-real_t BtShapeCylinder::get_radius() const {
+real_t BtCylinder::get_radius() const {
 	return cylinder.getRadius();
 }
 
-void BtShapeCylinder::set_height(real_t p_height) {
+void BtCylinder::set_height(real_t p_height) {
 	cylinder.setImplicitShapeDimensions(btVector3(get_radius() - get_margin(), (p_height * 0.5) - get_margin(), get_radius() - get_margin()));
 }
 
-real_t BtShapeCylinder::get_height() const {
+real_t BtCylinder::get_height() const {
 	return cylinder.getHalfExtentsWithMargin()[1] * 2.0;
 }
 
-void BtShapeCylinder::set_margin(real_t p_margin) {
+void BtCylinder::set_margin(real_t p_margin) {
 	// This already handles the Radius and Height adjustment.
 	cylinder.setMargin(p_margin);
 }
 
-real_t BtShapeCylinder::get_margin() const {
+real_t BtCylinder::get_margin() const {
 	return cylinder.getMargin();
 }
 
-void BtShapeWorldMargin::_bind_methods() {
+void BtWorldMargin::_bind_methods() {
 }
 
-void BtShapeWorldMargin::_get_storage_config(Dictionary &r_config) {
+void BtWorldMargin::_get_storage_config(Dictionary &r_config) {
 	/// Configure the storage of this component to have pages of 500 Physis Bodies
 	/// You can tweak this in editor.
 	r_config["page_size"] = 4;
 }
 
-BtShapeConvex::BtShapeConvex(const BtShapeConvex &p_other) :
+BtConvex::BtConvex(const BtConvex &p_other) :
 		BtRigidShape(TYPE_CONVEX) {
 	operator=(p_other);
 }
 
-BtShapeConvex &BtShapeConvex::operator=(const BtShapeConvex &p_other) {
+BtConvex &BtConvex::operator=(const BtConvex &p_other) {
 	point_count = p_other.point_count;
 
 	if (point_count > 0) {
@@ -209,23 +209,23 @@ BtShapeConvex &BtShapeConvex::operator=(const BtShapeConvex &p_other) {
 	return *this;
 }
 
-BtShapeConvex::~BtShapeConvex() {
+BtConvex::~BtConvex() {
 	if (points != nullptr) {
 		memdelete(points);
 	}
 }
 
-void BtShapeConvex::_bind_methods() {
-	ECS_BIND_PROPERTY_FUNC(BtShapeConvex, PropertyInfo(Variant::ARRAY, "points"), set_points, get_points);
+void BtConvex::_bind_methods() {
+	ECS_BIND_PROPERTY_FUNC(BtConvex, PropertyInfo(Variant::ARRAY, "points"), set_points, get_points);
 }
 
-void BtShapeConvex::_get_storage_config(Dictionary &r_config) {
+void BtConvex::_get_storage_config(Dictionary &r_config) {
 	/// Configure the storage of this component to have pages of 500 Physis Bodies
 	/// You can tweak this in editor.
 	r_config["page_size"] = 200;
 }
 
-void BtShapeConvex::set_points(const Vector<Vector3> &p_points) {
+void BtConvex::set_points(const Vector<Vector3> &p_points) {
 	point_count = p_points.size();
 	if (point_count == 0 && points != nullptr) {
 		memdelete(points);
@@ -241,7 +241,7 @@ void BtShapeConvex::set_points(const Vector<Vector3> &p_points) {
 	update_internal_shape();
 }
 
-Vector<Vector3> BtShapeConvex::get_points() const {
+Vector<Vector3> BtConvex::get_points() const {
 	Vector<Vector3> ret;
 	ret.resize(point_count);
 	Vector3 *ptrw = ret.ptrw();
@@ -251,7 +251,7 @@ Vector<Vector3> BtShapeConvex::get_points() const {
 	return ret;
 }
 
-void BtShapeConvex::update_internal_shape() {
+void BtConvex::update_internal_shape() {
 	const btVector3 local_scaling(1.0, 1.0, 1.0);
 	if (point_count == 0) {
 		convex.setPoints(nullptr, 0, true, local_scaling);
@@ -260,17 +260,17 @@ void BtShapeConvex::update_internal_shape() {
 	}
 }
 
-void BtShapeTrimesh::_bind_methods() {
-	ECS_BIND_PROPERTY_FUNC(BtShapeTrimesh, PropertyInfo(Variant::ARRAY, "faces"), set_faces, get_faces);
+void BtTrimesh::_bind_methods() {
+	ECS_BIND_PROPERTY_FUNC(BtTrimesh, PropertyInfo(Variant::ARRAY, "faces"), set_faces, get_faces);
 }
 
-void BtShapeTrimesh::_get_storage_config(Dictionary &r_config) {
+void BtTrimesh::_get_storage_config(Dictionary &r_config) {
 	/// Configure the storage of this component to have pages of 500 Physis Bodies
 	/// You can tweak this in editor.
 	r_config["page_size"] = 200;
 }
 
-void BtShapeTrimesh::set_faces(const Vector<Vector3> &p_faces) {
+void BtTrimesh::set_faces(const Vector<Vector3> &p_faces) {
 	faces = p_faces;
 
 	delete trimesh;
@@ -313,6 +313,6 @@ void BtShapeTrimesh::set_faces(const Vector<Vector3> &p_faces) {
 	}
 }
 
-Vector<Vector3> BtShapeTrimesh::get_faces() const {
+Vector<Vector3> BtTrimesh::get_faces() const {
 	return faces;
 }

--- a/modules/bullet_physics/components_rigid_shape.h
+++ b/modules/bullet_physics/components_rigid_shape.h
@@ -38,15 +38,15 @@ public:
 	}
 };
 
-struct BtShapeBox : public BtRigidShape {
-	COMPONENT_CUSTOM_CONSTRUCTOR(BtShapeBox, SharedSteadyStorage)
+struct BtBox : public BtRigidShape {
+	COMPONENT_CUSTOM_CONSTRUCTOR(BtBox, SharedSteadyStorage)
 
 	static void _bind_methods();
 	static void _get_storage_config(Dictionary &r_config);
 
 	btBoxShape box = btBoxShape(btVector3(1.0, 1.0, 1.0));
 
-	BtShapeBox() :
+	BtBox() :
 			BtRigidShape(TYPE_BOX) {}
 
 	void set_half_extents(const Vector3 &p_half_extends);
@@ -56,30 +56,30 @@ struct BtShapeBox : public BtRigidShape {
 	real_t get_margin() const;
 };
 
-struct BtShapeSphere : public BtRigidShape {
-	COMPONENT_CUSTOM_CONSTRUCTOR(BtShapeSphere, SharedSteadyStorage)
+struct BtSphere : public BtRigidShape {
+	COMPONENT_CUSTOM_CONSTRUCTOR(BtSphere, SharedSteadyStorage)
 
 	static void _bind_methods();
 	static void _get_storage_config(Dictionary &r_config);
 
 	btSphereShape sphere = btSphereShape(1.0);
 
-	BtShapeSphere() :
+	BtSphere() :
 			BtRigidShape(TYPE_SPHERE) {}
 
 	void set_radius(real_t p_radius);
 	real_t get_radius() const;
 };
 
-struct BtShapeCapsule : public BtRigidShape {
-	COMPONENT_CUSTOM_CONSTRUCTOR(BtShapeCapsule, SharedSteadyStorage)
+struct BtCapsule : public BtRigidShape {
+	COMPONENT_CUSTOM_CONSTRUCTOR(BtCapsule, SharedSteadyStorage)
 
 	static void _bind_methods();
 	static void _get_storage_config(Dictionary &r_config);
 
 	btCapsuleShape capsule = btCapsuleShape(1.0, 1.0); // Radius, Height
 
-	BtShapeCapsule() :
+	BtCapsule() :
 			BtRigidShape(TYPE_CAPSULE) {}
 
 	void set_radius(real_t p_radius);
@@ -89,15 +89,15 @@ struct BtShapeCapsule : public BtRigidShape {
 	real_t get_height() const;
 };
 
-struct BtShapeCone : public BtRigidShape {
-	COMPONENT_CUSTOM_CONSTRUCTOR(BtShapeCone, SharedSteadyStorage)
+struct BtCone : public BtRigidShape {
+	COMPONENT_CUSTOM_CONSTRUCTOR(BtCone, SharedSteadyStorage)
 
 	static void _bind_methods();
 	static void _get_storage_config(Dictionary &r_config);
 
 	btConeShape cone = btConeShape(1.0, 1.0); // Radius, Height
 
-	BtShapeCone() :
+	BtCone() :
 			BtRigidShape(TYPE_CONE) {}
 
 	void set_radius(real_t p_radius);
@@ -110,15 +110,15 @@ struct BtShapeCone : public BtRigidShape {
 	real_t get_margin() const;
 };
 
-struct BtShapeCylinder : public BtRigidShape {
-	COMPONENT_CUSTOM_CONSTRUCTOR(BtShapeCylinder, SharedSteadyStorage)
+struct BtCylinder : public BtRigidShape {
+	COMPONENT_CUSTOM_CONSTRUCTOR(BtCylinder, SharedSteadyStorage)
 
 	static void _bind_methods();
 	static void _get_storage_config(Dictionary &r_config);
 
 	btCylinderShape cylinder = btCylinderShape(btVector3(1.0, 1.0, 1.0)); // Half extents
 
-	BtShapeCylinder() :
+	BtCylinder() :
 			BtRigidShape(TYPE_CYLINDER) {}
 
 	void set_radius(real_t p_radius);
@@ -131,20 +131,20 @@ struct BtShapeCylinder : public BtRigidShape {
 	real_t get_margin() const;
 };
 
-struct BtShapeWorldMargin : public BtRigidShape {
-	COMPONENT_CUSTOM_CONSTRUCTOR(BtShapeWorldMargin, SharedSteadyStorage)
+struct BtWorldMargin : public BtRigidShape {
+	COMPONENT_CUSTOM_CONSTRUCTOR(BtWorldMargin, SharedSteadyStorage)
 
 	static void _bind_methods();
 	static void _get_storage_config(Dictionary &r_config);
 
 	btStaticPlaneShape world_margin = btStaticPlaneShape(btVector3(0, 1, 0), 0.0); // Normal, Distance
 
-	BtShapeWorldMargin() :
+	BtWorldMargin() :
 			BtRigidShape(TYPE_WORLD_MARGIN) {}
 };
 
-struct BtShapeConvex : public BtRigidShape {
-	COMPONENT_CUSTOM_CONSTRUCTOR(BtShapeConvex, SharedSteadyStorage)
+struct BtConvex : public BtRigidShape {
+	COMPONENT_CUSTOM_CONSTRUCTOR(BtConvex, SharedSteadyStorage)
 
 	static void _bind_methods();
 	static void _get_storage_config(Dictionary &r_config);
@@ -153,12 +153,12 @@ struct BtShapeConvex : public BtRigidShape {
 	uint32_t point_count = 0;
 	btConvexPointCloudShape convex = btConvexPointCloudShape();
 
-	BtShapeConvex() :
+	BtConvex() :
 			BtRigidShape(TYPE_CONVEX) {}
 	// Copy constructor is needed because I'm dealing with pointers here.
-	BtShapeConvex(const BtShapeConvex &p_other);
-	BtShapeConvex &operator=(const BtShapeConvex &p_other);
-	~BtShapeConvex();
+	BtConvex(const BtConvex &p_other);
+	BtConvex &operator=(const BtConvex &p_other);
+	~BtConvex();
 
 	void set_points(const Vector<Vector3> &p_points);
 	Vector<Vector3> get_points() const;
@@ -166,8 +166,8 @@ struct BtShapeConvex : public BtRigidShape {
 	void update_internal_shape();
 };
 
-struct BtShapeTrimesh : public BtRigidShape {
-	COMPONENT_CUSTOM_CONSTRUCTOR(BtShapeTrimesh, SharedSteadyStorage)
+struct BtTrimesh : public BtRigidShape {
+	COMPONENT_CUSTOM_CONSTRUCTOR(BtTrimesh, SharedSteadyStorage)
 
 	static void _bind_methods();
 	static void _get_storage_config(Dictionary &r_config);
@@ -177,7 +177,7 @@ struct BtShapeTrimesh : public BtRigidShape {
 	btTriangleInfoMap triangle_info_map;
 	btBvhTriangleMeshShape *trimesh = nullptr;
 
-	BtShapeTrimesh() :
+	BtTrimesh() :
 			BtRigidShape(TYPE_TRIMESH) {}
 
 	void set_faces(const Vector<Vector3> &p_faces);

--- a/modules/bullet_physics/register_types.cpp
+++ b/modules/bullet_physics/register_types.cpp
@@ -25,14 +25,14 @@ void register_bullet_physics_types() {
 	ECS::register_component<BtArea>();
 
 	// Shapes
-	ECS::register_component<BtShapeBox>();
-	ECS::register_component<BtShapeSphere>();
-	ECS::register_component<BtShapeCapsule>();
-	ECS::register_component<BtShapeCone>();
-	ECS::register_component<BtShapeCylinder>();
-	ECS::register_component<BtShapeWorldMargin>();
-	ECS::register_component<BtShapeConvex>();
-	ECS::register_component<BtShapeTrimesh>();
+	ECS::register_component<BtBox>();
+	ECS::register_component<BtSphere>();
+	ECS::register_component<BtCapsule>();
+	ECS::register_component<BtCone>();
+	ECS::register_component<BtCylinder>();
+	//ECS::register_component<BtWorldMargin>();
+	ECS::register_component<BtConvex>();
+	ECS::register_component<BtTrimesh>();
 
 	// Generics
 	// TODO move this inside `modules/godot`?
@@ -50,13 +50,13 @@ void register_bullet_physics_types() {
 	ECS::register_system(bt_body_sync, "BtBodySync", "Bullet Physics - Read the Physics Engine and update the Bodies");
 
 	// Register gizmos
-	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtShapeBoxGizmo));
-	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtShapeSphereGizmo));
-	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtShapeCapsuleGizmo));
-	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtShapeConeGizmo));
-	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtShapeCylinderGizmo));
-	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtShapeConvexGizmo));
-	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtShapeTrimeshGizmo));
+	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtBoxGizmo));
+	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtSphereGizmo));
+	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtCapsuleGizmo));
+	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtConeGizmo));
+	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtCylinderGizmo));
+	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtConvexGizmo));
+	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtTrimeshGizmo));
 }
 
 void unregister_bullet_physics_types() {

--- a/modules/godot/editor_plugins/entity_editor_plugin.h
+++ b/modules/godot/editor_plugins/entity_editor_plugin.h
@@ -40,7 +40,8 @@ public:
 	void _changed_callback();
 
 private:
-	const Dictionary &entity_get_components_data() const;
+	const OAHashMap<StringName, Variant> &entity_get_components_data() const;
+	Dictionary entity_get_component_props_data(const StringName &p_component) const;
 };
 
 class EditorInspectorPluginEntity : public EditorInspectorPlugin {

--- a/modules/godot/nodes/ecs_utilities.h
+++ b/modules/godot/nodes/ecs_utilities.h
@@ -92,6 +92,7 @@ String databag_validate_script(Ref<Script> p_script);
 /// - Save script systems.
 /// - Load script systems.
 class EditorEcs {
+	static bool def_defined_static_components;
 	/// Used to know if the previously stored `Component`s got loaded.
 	static bool component_loaded;
 	/// Used to know if the previously stored `System`s got loaded.
@@ -159,6 +160,8 @@ public:
 	static String system_save_script(const String &p_script_path, Ref<Script> p_script);
 
 	// ------------------------------------------------------------------ Runtime
+
+	static void define_editor_default_component_properties();
 
 	static void register_runtime_scripts();
 	static void register_dynamic_components();

--- a/modules/godot/nodes/entity.cpp
+++ b/modules/godot/nodes/entity.cpp
@@ -30,9 +30,6 @@ void EntityBase::remove_child(EntityID p_entity_id) {
 void Entity3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_entity_id"), &Entity3D::get_entity_id);
 
-	ClassDB::bind_method(D_METHOD("__set_components_data", "data"), &Entity3D::set_components_data);
-	ClassDB::bind_method(D_METHOD("__get_components_data"), &Entity3D::get_components_data);
-
 	ClassDB::bind_method(D_METHOD("add_component", "component_name", "values"), &Entity3D::add_component, DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("remove_component", "component_name"), &Entity3D::remove_component);
 	ClassDB::bind_method(D_METHOD("has_component", "component_name"), &Entity3D::has_component);
@@ -41,15 +38,10 @@ void Entity3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_component_value", "component", "property", "space"), &Entity3D::get_component_value, DEFVAL(Space::LOCAL));
 
 	ClassDB::bind_method(D_METHOD("clone", "world"), &Entity3D::clone);
-
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "__component_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "__set_components_data", "__get_components_data");
 }
 
 void Entity2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_entity_id"), &Entity2D::get_entity_id);
-
-	ClassDB::bind_method(D_METHOD("__set_components_data", "data"), &Entity2D::set_components_data);
-	ClassDB::bind_method(D_METHOD("__get_components_data"), &Entity2D::get_components_data);
 
 	ClassDB::bind_method(D_METHOD("add_component", "component_name", "values"), &Entity2D::add_component, DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("remove_component", "component_name"), &Entity2D::remove_component);
@@ -59,6 +51,4 @@ void Entity2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_component_value", "component", "property", "space"), &Entity2D::get_component_value, DEFVAL(Space::LOCAL));
 
 	ClassDB::bind_method(D_METHOD("clone", "world"), &Entity2D::clone);
-
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "__component_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "__set_components_data", "__get_components_data");
 }

--- a/modules/godot/nodes/entity.h
+++ b/modules/godot/nodes/entity.h
@@ -440,7 +440,7 @@ void EntityInternal<C>::add_component(const StringName &p_component_name, const 
 		// We are on editor.
 		if (EditorEcs::component_is_shared(p_component_name)) {
 			// This is a shared component.
-			components_data.insert(p_component_name, Variant());
+			components_data.set(p_component_name, Variant());
 		} else {
 			Variant *properties = components_data.lookup_ptr(p_component_name);
 			if (properties) {
@@ -451,7 +451,7 @@ void EntityInternal<C>::add_component(const StringName &p_component_name, const 
 				}
 			} else {
 				// This component doesn't exist yet, add it now.
-				components_data.insert(p_component_name, p_values.duplicate());
+				components_data.set(p_component_name, p_values.duplicate());
 			}
 			update_components_data();
 			owner->update_gizmo();
@@ -525,7 +525,7 @@ bool EntityInternal<C>::set_component_value(const StringName &p_component_name, 
 					// This component is new and not even init, so do it now.
 					shared->init(p_component_name);
 				}
-				components_data.insert(p_component_name, shared);
+				components_data.set(p_component_name, shared);
 			} else {
 				// Try to set the value inside the shared component instead
 				Variant *val = components_data.lookup_ptr(p_component_name);
@@ -547,7 +547,7 @@ bool EntityInternal<C>::set_component_value(const StringName &p_component_name, 
 			ERR_FAIL_COND_V(components_data.has(p_component_name) == false, false);
 
 			if (components_data.lookup_ptr(p_component_name)->get_type() != Variant::DICTIONARY) {
-				components_data.insert(p_component_name, Dictionary());
+				components_data.set(p_component_name, Dictionary());
 			}
 			(components_data.lookup_ptr(p_component_name)->operator Dictionary())[p_property_name] = p_value.duplicate();
 

--- a/modules/godot/nodes/entity.h
+++ b/modules/godot/nodes/entity.h
@@ -339,12 +339,18 @@ void EntityInternal<C>::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (OAHashMap<StringName, Variant>::Iterator it = components_data.iter(); it.valid; it = components_data.next_iter(it)) {
 		p_list->push_back(PropertyInfo(Variant::BOOL, *it.key, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 
-		const Dictionary &component_properties = it.value->operator Dictionary();
+		if (ECS::is_component_sharable(ECS::get_component_id(*it.key))) {
+			// This is a shared component
+			p_list->push_back(PropertyInfo(Variant::OBJECT, String(*it.key) + "/resource", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
+		} else {
+			// This is a common component.
+			const Dictionary &component_properties = it.value->operator Dictionary();
 
-		for (const Variant *key = component_properties.next(); key; key = component_properties.next(key)) {
-			const Variant *value = component_properties.getptr(*key);
-			p_list->push_back(PropertyInfo(value->get_type(), String(*it.key) + "/" + key->operator String(), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-			// TODO add here the default value?
+			for (const Variant *key = component_properties.next(); key; key = component_properties.next(key)) {
+				const Variant *value = component_properties.getptr(*key);
+				p_list->push_back(PropertyInfo(value->get_type(), String(*it.key) + "/" + key->operator String(), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
+				// TODO add here the default value?
+			}
 		}
 	}
 }

--- a/modules/godot/nodes/entity.h
+++ b/modules/godot/nodes/entity.h
@@ -545,7 +545,7 @@ bool EntityInternal<C>::set_component_value(const StringName &p_component_name, 
 					set_component_value(p_component_name, "", shared);
 				}
 
-				shared->get_component_data_mut()[p_property_name] = p_value;
+				shared->set_property_value(p_property_name, p_value);
 			}
 
 		} else {

--- a/modules/godot/nodes/shared_component_resource.cpp
+++ b/modules/godot/nodes/shared_component_resource.cpp
@@ -6,11 +6,7 @@ void SharedComponentResource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("__set_component_name", "name"), &SharedComponentResource::set_component_name);
 	ClassDB::bind_method(D_METHOD("__get_component_name"), &SharedComponentResource::get_component_name);
 
-	ClassDB::bind_method(D_METHOD("__set_component_data", "data"), &SharedComponentResource::set_component_data);
-	ClassDB::bind_method(D_METHOD("__get_component_data"), &SharedComponentResource::get_component_data);
-
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "component_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "__set_component_name", "__get_component_name");
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "component_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "__set_component_data", "__get_component_data");
 }
 
 bool SharedComponentResource::_set(const StringName &p_name, const Variant &p_property) {
@@ -82,12 +78,9 @@ StringName SharedComponentResource::get_component_name() const {
 	return component_name;
 }
 
-void SharedComponentResource::set_component_data(const Dictionary &p_component) {
-	component_data = p_component;
-}
-
-Dictionary &SharedComponentResource::get_component_data_mut() {
-	return component_data;
+void SharedComponentResource::set_property_value(const StringName &p_property, const Variant &p_val) {
+	component_data[p_property] = p_val;
+	notify_property_list_changed();
 }
 
 const Dictionary &SharedComponentResource::get_component_data() const {

--- a/modules/godot/nodes/shared_component_resource.h
+++ b/modules/godot/nodes/shared_component_resource.h
@@ -45,8 +45,7 @@ public:
 	void set_component_name(const StringName &p_component_name);
 	StringName get_component_name() const;
 
-	void set_component_data(const Dictionary &p_component);
-	Dictionary &get_component_data_mut(); // Using `_mut` so the bind method doesn't go crazy.
+	void set_property_value(const StringName &p_property, const Variant &p_val);
 	const Dictionary &get_component_data() const;
 
 	virtual Ref<Resource> duplicate(bool p_subresources = false) const override;

--- a/modules/godot/register_types.cpp
+++ b/modules/godot/register_types.cpp
@@ -35,6 +35,7 @@ public:
 				// Add component gizmos:
 				Node3DEditor::get_singleton()->add_gizmo_plugin(Ref<Components3DGizmoPlugin>(Components3DGizmoPlugin::get_singleton()));
 			}
+			EditorEcs::define_editor_default_component_properties();
 		} else {
 			// Load the Scripted Components/Databags/Systems
 			EditorEcs::register_runtime_scripts();

--- a/pipeline/pipeline.cpp
+++ b/pipeline/pipeline.cpp
@@ -174,6 +174,7 @@ void Pipeline::prepare(World *p_world) {
 		for (const Set<uint32_t>::Element *e = info.need_changed.front(); e; e = e->next()) {
 			// Mark as `need_changed` this storage.
 			StorageBase *storage = p_world->get_storage(e->get());
+			ERR_CONTINUE_MSG(storage == nullptr, "The storage is not supposed to be nullptr at this point. Storage: " + ECS::get_component_name(e->get()) + "#" + itos(e->get()));
 			storage->set_tracing_change(true);
 		}
 	}


### PR DESCRIPTION
Improved how the Entity nodes (`Entity3D`, `Entity2D`) are stored. Now it's possible to inherit a scene containing entities.

**This is a breaking change, The entities in your scene will lose the components and its necessary to assign again.**