### PR TITLE
Improve event component registration syntax.

### DIFF
--- a/components/component.h
+++ b/components/component.h
@@ -101,4 +101,7 @@ const T *unwrap_component(const Object *p_access_databag) {
 		return nullptr;
 	}
 }
+
+#define EVENT() \
+	void __is_event() {}
 } // namespace godex

--- a/ecs.h
+++ b/ecs.h
@@ -128,9 +128,6 @@ public:
 	template <class C>
 	static void register_component(StorageBase *(*create_storage)());
 
-	template <class E>
-	static void register_component_event();
-
 	// TODO specify the storage here?
 	static uint32_t register_script_component(const StringName &p_name, const LocalVector<ScriptProperty> &p_properties, StorageType p_storage_type, Vector<StringName> p_spawners);
 	static uint32_t register_script_component_event(const StringName &p_name, const LocalVector<ScriptProperty> &p_properties, StorageType p_storage_type, Vector<StringName> p_spawners);
@@ -409,20 +406,11 @@ void ECS::register_component(StorageBase *(*create_storage)()) {
 	// Add a new scripting constant, for fast and easy `component` access.
 	ClassDB::bind_integer_constant(get_class_static(), StringName(), component_name, C::component_id);
 
+	if constexpr (godex_has_is_event<C>::value) {
+		components_info[C::component_id].is_event = true;
+	}
+
 	print_line("Component: " + component_name + " registered with ID: " + itos(C::component_id));
-}
-
-template <class E>
-void ECS::register_component_event() {
-	ERR_FAIL_COND_MSG(E::get_component_id() != UINT32_MAX, "This component event is already registered.");
-	register_component<E>();
-
-#ifdef DEBUG_ENABLED
-	// `register_component` is not supposed to fail.
-	CRASH_COND(E::get_component_id() == UINT32_MAX);
-#endif
-
-	components_info[E::get_component_id()].is_event = true;
 }
 
 template <class R>

--- a/ecs_types.h
+++ b/ecs_types.h
@@ -26,6 +26,12 @@ struct godex_has_storage_config : std::false_type {};
 template <typename T>
 struct godex_has_storage_config<T, decltype(void(std::declval<T &>()._get_storage_config(std::declval<Dictionary &>())))> : std::true_type {};
 
+template <typename T, typename = void>
+struct godex_has_is_event : std::false_type {};
+
+template <typename T>
+struct godex_has_is_event<T, decltype(void(std::declval<T &>().__is_event()))> : std::true_type {};
+
 #define ECSCLASS(m_class)                             \
 private:                                              \
 	friend class ECS;                                 \

--- a/tests/test_ecs_system.h
+++ b/tests/test_ecs_system.h
@@ -39,6 +39,7 @@ struct TestSystem1Databag : public godex::Databag {
 
 struct Event1Component {
 	COMPONENT_BATCH(Event1Component, DenseVector, 2)
+	EVENT()
 
 	static void _bind_methods() {
 		ECS_BIND_PROPERTY(Event1Component, PropertyInfo(Variant::INT, "a"), a);
@@ -475,7 +476,7 @@ TEST_CASE("[Modules][ECS] Test system databag fetch with dynamic query.") {
 }
 
 TEST_CASE("[Modules][ECS] Test event mechanism.") {
-	ECS::register_component_event<Event1Component>();
+	ECS::register_component<Event1Component>();
 
 	World world;
 


### PR DESCRIPTION
Removed the function `ECS::register_component_event`. Is now possible to
mark a component an event component using the macro `EVENT`, and it's
possible to register it using the usual function `ECS::register_component<>()`.

```cpp
struct MyEventComponent {
	COMPONENT(MyEventComponent, DenseVectorStorage)
	EVENT()
};
```