### PR TITLE
Improved TransformComponent and introduced Depot

### DIFF
--- a/components/component.h
+++ b/components/component.h
@@ -8,23 +8,25 @@
 
 namespace godex {
 
-#define COMPONENT_INTERNAL(m_class)                             \
-	/* Components */                                            \
-	static inline uint32_t component_id = UINT32_MAX;           \
-                                                                \
-public:                                                         \
-	static uint32_t get_component_id() { return component_id; } \
-	ECS_PROPERTY_MAPPER(m_class)                                \
-	ECS_METHOD_MAPPER(m_class)                                  \
-	static void __static_destructor() {                         \
-		property_map.reset();                                   \
-		properties.reset();                                     \
-		setters.reset();                                        \
-		getters.reset();                                        \
-		methods_map.reset();                                    \
-		methods.reset();                                        \
-	}                                                           \
-                                                                \
+#define COMPONENT_INTERNAL(m_class)                                                    \
+	/* Components */                                                                   \
+	static inline uint32_t component_id = UINT32_MAX;                                  \
+                                                                                       \
+public:                                                                                \
+	static void *new_component() { return new m_class; }                               \
+	static void free_component(void *p_component) { delete ((m_class *)p_component); } \
+	static uint32_t get_component_id() { return component_id; }                        \
+	ECS_PROPERTY_MAPPER(m_class)                                                       \
+	ECS_METHOD_MAPPER(m_class)                                                         \
+	static void __static_destructor() {                                                \
+		property_map.reset();                                                          \
+		properties.reset();                                                            \
+		setters.reset();                                                               \
+		getters.reset();                                                               \
+		methods_map.reset();                                                           \
+		methods.reset();                                                               \
+	}                                                                                  \
+                                                                                       \
 public:
 
 /// Register a component and allow to use a custom constructor.

--- a/ecs.cpp
+++ b/ecs.cpp
@@ -595,6 +595,8 @@ uint32_t ECS::register_script_component(
 			ComponentInfo{
 					nullptr,
 					nullptr,
+					nullptr,
+					nullptr,
 					info,
 					false,
 					false,
@@ -642,6 +644,16 @@ StorageBase *ECS::create_storage(uint32_t p_component_id) {
 		// This is a native component.
 		return components_info[p_component_id].create_storage();
 	}
+}
+
+void *ECS::new_component(godex::component_id p_component_id) {
+	ERR_FAIL_COND_V_MSG(ECS::verify_component_id(p_component_id) == false, nullptr, "This component id " + itos(p_component_id) + " is not valid.");
+	return components_info[p_component_id].new_component();
+}
+
+void ECS::free_component(godex::component_id p_component_id, void *p_component) {
+	ERR_FAIL_COND_MSG(ECS::verify_component_id(p_component_id) == false, "This component id " + itos(p_component_id) + " is not valid.");
+	components_info[p_component_id].free_component(p_component);
 }
 
 void ECS::get_storage_config(godex::component_id p_component_id, Dictionary &r_config) {

--- a/ecs.h
+++ b/ecs.h
@@ -37,6 +37,8 @@ struct SpawnerInfo {
 /// component registration.
 struct ComponentInfo {
 	StorageBase *(*create_storage)();
+	void *(*new_component)();
+	void (*free_component)(void *);
 	void (*get_storage_config)(Dictionary &);
 	DynamicComponentInfo *dynamic_component_info = nullptr;
 	bool notify_release_write = false;
@@ -136,6 +138,8 @@ public:
 	static bool verify_component_id(uint32_t p_component_id);
 
 	static StorageBase *create_storage(godex::component_id p_component_id);
+	static void *new_component(godex::component_id p_component_id);
+	static void free_component(godex::component_id p_component_id, void *p_component);
 	static void get_storage_config(godex::component_id p_component_id, Dictionary &r_config);
 	static const LocalVector<StringName> &get_registered_components();
 	static godex::component_id get_component_id(StringName p_component_name);
@@ -385,6 +389,8 @@ void ECS::register_component(StorageBase *(*create_storage)()) {
 	components_info.push_back(
 			ComponentInfo{
 					create_storage,
+					C::new_component,
+					C::free_component,
 					get_storage_config,
 					nullptr,
 					notify_release_write,

--- a/modules/bullet_physics/components_gizmos.cpp
+++ b/modules/bullet_physics/components_gizmos.cpp
@@ -127,7 +127,9 @@ void BtBoxGizmo::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Vari
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Shape Box Half Extent"));
 		ur->add_do_method(entity, "set_component_value", box_component_name, half_extents_name, half_extents);
-		ur->add_undo_method(entity, "set_component_value", box_component_name, half_extents_name, p_restore);
+		Vector3 restore = half_extents;
+		restore[p_idx] = p_restore;
+		ur->add_undo_method(entity, "set_component_value", box_component_name, half_extents_name, restore);
 		ur->commit_action();
 	}
 }

--- a/modules/bullet_physics/systems_base.cpp
+++ b/modules/bullet_physics/systems_base.cpp
@@ -104,7 +104,7 @@ void bt_body_config(
 			// Set transfrorm
 			btTransform t;
 			if (transform != nullptr) {
-				G_TO_B(transform->transform, t);
+				G_TO_B(*transform, t);
 			} else {
 				t.setIdentity();
 			}
@@ -188,7 +188,7 @@ void bt_area_config(
 			// Set transfrorm
 			btTransform t;
 			if (transform != nullptr) {
-				G_TO_B(transform->transform, t);
+				G_TO_B(*transform, t);
 			} else {
 				t.setIdentity();
 			}
@@ -451,7 +451,7 @@ void bt_body_sync(
 		p_spaces->get_space(w_i)->moved_bodies.for_each([&](EntityID p_entity_id) {
 			if (p_query.has(p_entity_id)) {
 				auto [body, transform] = p_query.space(GLOBAL)[p_entity_id];
-				B_TO_G(body->get_motion_state()->transf, transform->transform);
+				B_TO_G(body->get_motion_state()->transf, *transform);
 			}
 		});
 

--- a/modules/godot/components/transform_component.cpp
+++ b/modules/godot/components/transform_component.cpp
@@ -1,10 +1,12 @@
 #include "transform_component.h"
 
+#include "core/math/math_funcs.h"
+
 void TransformComponent::_bind_methods() {
 	// TODO remove this.
 	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), set_self_script, get_self_script);
 	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::VECTOR3, "origin", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), origin);
-	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::VECTOR3, "rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), set_rotation, get_rotation);
+	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::VECTOR3, "rotation_deg", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), set_rotation_deg, get_rotation_deg);
 	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::VECTOR3, "scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), set_scale, get_scale);
 
 	// Usage is set to 0 because we need to expose this only to scripts.
@@ -35,6 +37,21 @@ void TransformComponent::set_rotation(const Vector3 &p_euler) {
 
 const Vector3 TransformComponent::get_rotation() const {
 	return basis.get_euler();
+}
+
+void TransformComponent::set_rotation_deg(const Vector3 &p_euler) {
+	set_rotation(Vector3(
+			Math::deg2rad(p_euler[0]),
+			Math::deg2rad(p_euler[1]),
+			Math::deg2rad(p_euler[2])));
+}
+
+const Vector3 TransformComponent::get_rotation_deg() const {
+	const Vector3 r = get_rotation();
+	return Vector3(
+			Math::rad2deg(r[0]),
+			Math::rad2deg(r[1]),
+			Math::rad2deg(r[2]));
 }
 
 void TransformComponent::set_scale(const Vector3 &p_scale) {

--- a/modules/godot/components/transform_component.cpp
+++ b/modules/godot/components/transform_component.cpp
@@ -22,12 +22,10 @@ TransformComponent::TransformComponent(const Transform &p_transform) :
 }
 
 void TransformComponent::set_self_script(const Transform &p_transf) {
-	WARN_PRINT_ONCE("TtransformComponent::set_transform is deprecated. Don't use it please.");
 	*this = p_transf;
 }
 
 Transform TransformComponent::get_self_script() const {
-	WARN_PRINT_ONCE("TtransformComponent::get_transform is deprecated. Don't use it please.");
 	return *this;
 }
 

--- a/modules/godot/components/transform_component.cpp
+++ b/modules/godot/components/transform_component.cpp
@@ -2,9 +2,13 @@
 
 void TransformComponent::_bind_methods() {
 	// TODO remove this.
-	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), deprecated_set_transform, deprecated_get_transform);
+	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), set_self_script, get_self_script);
 	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::VECTOR3, "origin", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), origin);
 	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::VECTOR3, "rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), set_rotation, get_rotation);
+	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::VECTOR3, "scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), set_scale, get_scale);
+
+	// Usage is set to 0 because we need to expose this only to scripts.
+	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::VECTOR3, "basis", PROPERTY_HINT_NONE, "", 0), origin);
 }
 
 void TransformComponent::_get_storage_config(Dictionary &r_dictionary) {
@@ -15,22 +19,30 @@ TransformComponent::TransformComponent(const Transform &p_transform) :
 		Transform(p_transform.basis, p_transform.origin) {
 }
 
-void TransformComponent::deprecated_set_transform(const Transform &p_transf) {
+void TransformComponent::set_self_script(const Transform &p_transf) {
 	WARN_PRINT_ONCE("TtransformComponent::set_transform is deprecated. Don't use it please.");
 	*this = p_transf;
 }
 
-Transform TransformComponent::deprecated_get_transform() const {
+Transform TransformComponent::get_self_script() const {
 	WARN_PRINT_ONCE("TtransformComponent::get_transform is deprecated. Don't use it please.");
 	return *this;
 }
 
 void TransformComponent::set_rotation(const Vector3 &p_euler) {
-	basis.set_euler(p_euler);
+	basis.set_euler_scale(p_euler, basis.get_scale_local());
 }
 
 const Vector3 TransformComponent::get_rotation() const {
 	return basis.get_euler();
+}
+
+void TransformComponent::set_scale(const Vector3 &p_scale) {
+	basis.set_euler_scale(basis.get_euler(), p_scale);
+}
+
+const Vector3 TransformComponent::get_scale() const {
+	return basis.get_scale();
 }
 
 void TransformComponent::combine(

--- a/modules/godot/components/transform_component.cpp
+++ b/modules/godot/components/transform_component.cpp
@@ -1,7 +1,10 @@
 #include "transform_component.h"
 
 void TransformComponent::_bind_methods() {
-	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform"), transform);
+	// TODO remove this.
+	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), deprecated_set_transform, deprecated_get_transform);
+	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::VECTOR3, "origin", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), origin);
+	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::VECTOR3, "rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), set_rotation, get_rotation);
 }
 
 void TransformComponent::_get_storage_config(Dictionary &r_dictionary) {
@@ -9,19 +12,37 @@ void TransformComponent::_get_storage_config(Dictionary &r_dictionary) {
 }
 
 TransformComponent::TransformComponent(const Transform &p_transform) :
-		transform(p_transform) {
+		Transform(p_transform.basis, p_transform.origin) {
+}
+
+void TransformComponent::deprecated_set_transform(const Transform &p_transf) {
+	WARN_PRINT_ONCE("TtransformComponent::set_transform is deprecated. Don't use it please.");
+	*this = p_transf;
+}
+
+Transform TransformComponent::deprecated_get_transform() const {
+	WARN_PRINT_ONCE("TtransformComponent::get_transform is deprecated. Don't use it please.");
+	return *this;
+}
+
+void TransformComponent::set_rotation(const Vector3 &p_euler) {
+	basis.set_euler(p_euler);
+}
+
+const Vector3 TransformComponent::get_rotation() const {
+	return basis.get_euler();
 }
 
 void TransformComponent::combine(
 		const TransformComponent &p_local,
 		const TransformComponent &p_parent_global,
 		TransformComponent &r_global) {
-	r_global.transform = p_parent_global.transform * p_local.transform;
+	r_global = p_parent_global * p_local;
 }
 
 void TransformComponent::combine_inverse(
 		const TransformComponent &p_global,
 		const TransformComponent &p_parent_global,
 		TransformComponent &r_local) {
-	r_local.transform = p_parent_global.transform.inverse() * p_global.transform;
+	r_local = p_parent_global.inverse() * p_global;
 }

--- a/modules/godot/components/transform_component.cpp
+++ b/modules/godot/components/transform_component.cpp
@@ -3,7 +3,6 @@
 #include "core/math/math_funcs.h"
 
 void TransformComponent::_bind_methods() {
-	// TODO remove this.
 	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::TRANSFORM, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), set_self_script, get_self_script);
 	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::VECTOR3, "origin", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), origin);
 	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::VECTOR3, "rotation_deg", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), set_rotation_deg, get_rotation_deg);

--- a/modules/godot/components/transform_component.h
+++ b/modules/godot/components/transform_component.h
@@ -12,12 +12,14 @@ class TransformComponent : public Transform {
 
 	TransformComponent(const Transform &p_transform);
 
-	// TODO remove thes please.
-	void deprecated_set_transform(const Transform &p_transf);
-	Transform deprecated_get_transform() const;
+	void set_self_script(const Transform &p_transf);
+	Transform get_self_script() const;
 
 	void set_rotation(const Vector3 &p_euler);
 	const Vector3 get_rotation() const;
+
+	void set_scale(const Vector3 &p_scale);
+	const Vector3 get_scale() const;
 
 	/// Used by the `HierarchyStorage` to combine the local data with the parent
 	/// global data, and obtain this global.

--- a/modules/godot/components/transform_component.h
+++ b/modules/godot/components/transform_component.h
@@ -4,14 +4,20 @@
 #include "../../../storage/hierarchical_storage.h"
 #include "core/math/transform.h"
 
-class TransformComponent {
+class TransformComponent : public Transform {
 	COMPONENT(TransformComponent, HierarchicalStorage)
+
 	static void _bind_methods();
 	static void _get_storage_config(Dictionary &r_dictionary);
 
-	Transform transform;
-
 	TransformComponent(const Transform &p_transform);
+
+	// TODO remove thes please.
+	void deprecated_set_transform(const Transform &p_transf);
+	Transform deprecated_get_transform() const;
+
+	void set_rotation(const Vector3 &p_euler);
+	const Vector3 get_rotation() const;
 
 	/// Used by the `HierarchyStorage` to combine the local data with the parent
 	/// global data, and obtain this global.

--- a/modules/godot/components/transform_component.h
+++ b/modules/godot/components/transform_component.h
@@ -18,6 +18,9 @@ class TransformComponent : public Transform {
 	void set_rotation(const Vector3 &p_euler);
 	const Vector3 get_rotation() const;
 
+	void set_rotation_deg(const Vector3 &p_euler);
+	const Vector3 get_rotation_deg() const;
+
 	void set_scale(const Vector3 &p_scale);
 	const Vector3 get_scale() const;
 

--- a/modules/godot/editor_plugins/entity_editor_plugin.cpp
+++ b/modules/godot/editor_plugins/entity_editor_plugin.cpp
@@ -128,6 +128,11 @@ void EntityEditor::create_component_inspector(StringName p_component_name, VBoxC
 		for (List<PropertyInfo>::Element *e = properties.front(); e; e = e->next()) {
 			EditorProperty *prop = nullptr;
 
+			if ((e->get().usage & PROPERTY_USAGE_EDITOR) == 0) {
+				// This property is not meant to be displayed on editor.
+				continue;
+			}
+
 			switch (e->get().type) {
 				case Variant::NIL: {
 					prop = memnew(EditorPropertyNil);

--- a/modules/godot/editor_plugins/entity_editor_plugin.cpp
+++ b/modules/godot/editor_plugins/entity_editor_plugin.cpp
@@ -77,8 +77,8 @@ void EntityEditor::update_editors() {
 		}
 		components_properties.clear();
 
-		const OAHashMap<StringName, Variant> &components = entity_get_components_data();
-		for (OAHashMap<StringName, Variant>::Iterator it = components.iter(); it.valid; it = components.next_iter(it)) {
+		const OAHashMap<StringName, Ref<ComponentDepot>> &components = entity_get_components_data();
+		for (OAHashMap<StringName, Ref<ComponentDepot>>::Iterator it = components.iter(); it.valid; it = components.next_iter(it)) {
 			// Add the components of this Entity
 			EditorInspectorSection *component_section = memnew(EditorInspectorSection);
 			component_section->setup("component_" + String(*it.key), String(*it.key), entity, section_color, true);
@@ -668,7 +668,7 @@ void EntityEditor::_changed_callback() {
 	update_editors();
 }
 
-const OAHashMap<StringName, Variant> &EntityEditor::entity_get_components_data() const {
+const OAHashMap<StringName, Ref<ComponentDepot>> &EntityEditor::entity_get_components_data() const {
 	Entity3D *e = Object::cast_to<Entity3D>(entity);
 	if (e) {
 		return e->get_components_data();

--- a/modules/godot/editor_plugins/entity_editor_plugin.h
+++ b/modules/godot/editor_plugins/entity_editor_plugin.h
@@ -7,6 +7,7 @@
 class EntityEditorPlugin;
 class EditorInspectorPluginEntity;
 class Entity3D;
+class ComponentDepot;
 
 class EntityEditor : public VBoxContainer {
 	GDCLASS(EntityEditor, VBoxContainer);
@@ -40,7 +41,7 @@ public:
 	void _changed_callback();
 
 private:
-	const OAHashMap<StringName, Variant> &entity_get_components_data() const;
+	const OAHashMap<StringName, Ref<ComponentDepot>> &entity_get_components_data() const;
 	Dictionary entity_get_component_props_data(const StringName &p_component) const;
 };
 

--- a/modules/godot/nodes/ecs_utilities.cpp
+++ b/modules/godot/nodes/ecs_utilities.cpp
@@ -700,8 +700,9 @@ bool SharedComponentDepot::_setv(const StringName &p_name, const Variant &p_valu
 			data->init(component_name);
 		}
 
-		data->set_property_value(p_name, p_value);
-		return true;
+		bool success = false;
+		data->set(p_name, p_value, &success);
+		return success;
 	}
 }
 

--- a/modules/godot/nodes/ecs_utilities.h
+++ b/modules/godot/nodes/ecs_utilities.h
@@ -191,6 +191,8 @@ class StaticComponentDepot : public ComponentDepot {
 	godex::component_id component_id = godex::COMPONENT_NONE;
 
 public:
+	godex::component_id get_component_id() const { return component_id; }
+
 	virtual ~StaticComponentDepot();
 
 	virtual void init(const StringName &p_name) override;

--- a/modules/godot/nodes/ecs_utilities.h
+++ b/modules/godot/nodes/ecs_utilities.h
@@ -6,6 +6,7 @@
 #include "core/templates/oa_hash_map.h"
 
 class Script;
+class SharedComponentResource;
 
 namespace godex {
 class DynamicSystemInfo;
@@ -170,4 +171,56 @@ public:
 
 private:
 	static bool save_script(const String &p_setting_list_name, const String &p_script_path);
+};
+
+/// Used by the Entity3D & Entity2D to store the entity variables, when the
+/// entity is not inside a world.
+class ComponentDepot : public Reference {
+protected:
+	StringName component_name;
+
+public:
+	virtual ~ComponentDepot();
+
+	virtual void init(const StringName &p_name) = 0;
+	virtual Dictionary get_properties_data() const = 0;
+};
+
+class StaticComponentDepot : public ComponentDepot {
+	void *component = nullptr;
+	godex::component_id component_id = godex::COMPONENT_NONE;
+
+public:
+	virtual ~StaticComponentDepot();
+
+	virtual void init(const StringName &p_name) override;
+
+	virtual bool _setv(const StringName &p_name, const Variant &p_value) override;
+	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override;
+
+	virtual Dictionary get_properties_data() const override;
+};
+
+class ScriptComponentDepot : public ComponentDepot {
+	Dictionary data;
+
+public:
+	virtual void init(const StringName &p_name) override;
+
+	virtual bool _setv(const StringName &p_name, const Variant &p_value) override;
+	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override;
+
+	virtual Dictionary get_properties_data() const override;
+};
+
+class SharedComponentDepot : public ComponentDepot {
+	Ref<SharedComponentResource> data;
+
+public:
+	virtual void init(const StringName &p_name) override;
+
+	virtual bool _setv(const StringName &p_name, const Variant &p_value) override;
+	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override;
+
+	virtual Dictionary get_properties_data() const override;
 };

--- a/modules/godot/nodes/ecs_world.cpp
+++ b/modules/godot/nodes/ecs_world.cpp
@@ -612,7 +612,7 @@ void WorldECS::sync_3d_transforms() {
 		EntityID entity = entity_node->get_entity_id();
 		if (entity.is_valid() && storage->has(entity)) {
 			const TransformComponent *t = storage->get(entity, Space::GLOBAL);
-			entity_node->set_global_transform(t->transform);
+			entity_node->set_global_transform(*t);
 		}
 	}
 }

--- a/modules/godot/nodes/entity.h
+++ b/modules/godot/nodes/entity.h
@@ -610,8 +610,13 @@ bool EntityInternal<C>::set_component_value(const StringName &p_component_name, 
 			Transform t = Variant(owner->get_transform());
 			if (p_property_name == "origin") {
 				t.origin = p_value;
+
 			} else if (p_property_name == "rotation") {
-				t.basis.set_euler(p_value);
+				t.basis.set_euler_scale(p_value, t.basis.get_scale_local());
+
+			} else if (p_property_name == "scale") {
+				t.basis.set_euler_scale(t.basis.get_euler(), p_value);
+
 			} else if (p_property_name == "transform") {
 				t = p_value;
 			}

--- a/modules/godot/nodes/entity.h
+++ b/modules/godot/nodes/entity.h
@@ -603,24 +603,26 @@ bool EntityInternal<C>::set_component_value(const StringName &p_component_name, 
 		ERR_FAIL_COND_V_MSG(val == nullptr || val->is_null(), false, "This component" + p_component_name + " is not set on this entity.");
 
 		bool success = false;
-		(*val)->set(p_property_name, p_value, &success);
 
 		// Hack to propagate `Node3D` transform change.
-		if (p_component_name == "TransformComponent") {
-			Transform t = Variant(owner->get_transform());
+		if (Object::cast_to<Entity3D>(owner) != nullptr &&
+				p_component_name == "TransformComponent") {
+			Entity3D *entity = (Entity3D *)owner;
 			if (p_property_name == "origin") {
-				t.origin = p_value;
+				entity->set_translation(p_value);
 
-			} else if (p_property_name == "rotation") {
-				t.basis.set_euler_scale(p_value, t.basis.get_scale_local());
+			} else if (p_property_name == "rotation_deg") {
+				entity->set_rotation_degrees(p_value);
 
 			} else if (p_property_name == "scale") {
-				t.basis.set_euler_scale(t.basis.get_euler(), p_value);
+				entity->set_scale(p_value);
 
 			} else if (p_property_name == "transform") {
-				t = p_value;
+				entity->set_transform(p_value);
 			}
-			owner->set_transform(Variant(t));
+			(*val)->set("transform", Variant(owner->get_transform()), &success);
+		} else {
+			(*val)->set(p_property_name, p_value, &success);
 		}
 
 		owner->update_gizmo();

--- a/modules/godot/nodes/entity.h
+++ b/modules/godot/nodes/entity.h
@@ -520,22 +520,19 @@ void EntityInternal<C>::add_component(const StringName &p_component_name, const 
 			// This is a shared component.
 			Ref<SharedComponentDepot> d;
 			d.instance();
-			d->init(p_component_name);
-			components_data.set(p_component_name, d);
 			depot = d;
 		} else if (EditorEcs::is_script_component(p_component_name)) {
 			Ref<ScriptComponentDepot> d;
 			d.instance();
-			d->init(p_component_name);
-			components_data.set(p_component_name, d);
 			depot = d;
 		} else {
 			Ref<StaticComponentDepot> d;
 			d.instance();
-			d->init(p_component_name);
-			components_data.set(p_component_name, d);
 			depot = d;
 		}
+
+		components_data.set(p_component_name, depot);
+		depot->init(p_component_name);
 
 		// Append properties.
 		for (const Variant *key = p_values.next(); key; key = p_values.next(key)) {

--- a/modules/godot/nodes/shared_component_resource.h
+++ b/modules/godot/nodes/shared_component_resource.h
@@ -4,6 +4,8 @@
 #include "../../../ecs.h"
 #include "core/io/resource.h"
 
+class StaticComponentDepot;
+
 struct WorldSIDPair {
 	void *world;
 	godex::SID sid;
@@ -23,8 +25,8 @@ class SharedComponentResource : public Resource {
 
 	StringName component_name;
 
-	/// Component initializatin data.
-	Dictionary component_data;
+	/// Component data.
+	Ref<StaticComponentDepot> depot;
 
 	/// List of `SID` for each `World`.
 	/// The `void *` is the World pointer, and it's here just as index to store
@@ -44,9 +46,6 @@ public:
 
 	void set_component_name(const StringName &p_component_name);
 	StringName get_component_name() const;
-
-	void set_property_value(const StringName &p_property, const Variant &p_val);
-	const Dictionary &get_component_data() const;
 
 	virtual Ref<Resource> duplicate(bool p_subresources = false) const override;
 };

--- a/modules/godot/systems/mesh_updater_system.cpp
+++ b/modules/godot/systems/mesh_updater_system.cpp
@@ -59,7 +59,7 @@ void mesh_transform_updater_system(
 
 	for (auto [mesh, transf] : p_query.space(Space::GLOBAL)) {
 		if (mesh->instance != RID()) {
-			rs->get_rs()->instance_set_transform(mesh->instance, transf->transform);
+			rs->get_rs()->instance_set_transform(mesh->instance, *transf);
 		}
 	}
 }

--- a/tests/test_ecs_component.h
+++ b/tests/test_ecs_component.h
@@ -1,0 +1,24 @@
+#ifndef TEST_ECS_COMPONENT_H
+#define TEST_ECS_COMPONENT_H
+
+#include "tests/test_macros.h"
+
+#include "../ecs.h"
+#include "../modules/godot/components/transform_component.h"
+
+namespace godex_component_test {
+
+TEST_CASE("[Modules][ECS] Test component create pointer.") {
+	void *transform = ECS::new_component(TransformComponent::get_component_id());
+	CHECK(transform != nullptr);
+
+	ECS::unsafe_component_set_by_name(TransformComponent::get_component_id(), transform, "origin", Vector3(1, 2, 3));
+	const Vector3 vec = ECS::unsafe_component_get_by_name(TransformComponent::get_component_id(), transform, "origin");
+
+	CHECK(vec.distance_to(Vector3(1, 2, 3)) <= CMP_EPSILON);
+
+	ECS::free_component(TransformComponent::get_component_id(), transform);
+}
+} // namespace godex_component_test
+
+#endif // TEST_ECS_COMOPNENT_H

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -262,7 +262,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 			CHECK(ptr_c == &c);
 		}
 
-		transf.transform.origin.x = -50;
+		transf.origin.x = -50;
 
 		{
 			auto [transform_ptr, ptr_a, ptr_b, ptr_c] = tuple;
@@ -272,7 +272,7 @@ TEST_CASE("[Modules][ECS] Test QueryResultTuple: packing and unpaking following 
 			CHECK(ptr_b == &b);
 			CHECK(ptr_c == &c);
 
-			CHECK(ABS(transform_ptr->transform.origin.x - transf.transform.origin.x) <= CMP_EPSILON);
+			CHECK(ABS(transform_ptr->origin.x - transf.origin.x) <= CMP_EPSILON);
 		}
 	}
 
@@ -565,7 +565,7 @@ TEST_CASE("[Modules][ECS] Test static query") {
 		CHECK(query.has(entity_2));
 		CHECK(query.has(entity_3) == false);
 		auto [transform, tag] = query[entity_2];
-		CHECK(ABS(transform->transform.origin.z - 23.0) <= CMP_EPSILON);
+		CHECK(ABS(transform->origin.z - 23.0) <= CMP_EPSILON);
 		CHECK(tag == nullptr);
 	}
 

--- a/tests/test_ecs_storage_hierarchical.h
+++ b/tests/test_ecs_storage_hierarchical.h
@@ -246,9 +246,9 @@ TEST_CASE("[Modules][ECS] Test HierarchicalStorage.") {
 		const TransformComponent *tc_entity_2 = std::as_const(transform_storage).get(2);
 
 		// Test local world space.
-		CHECK(ABS(tc_entity_0->transform.origin[0] - 1.) <= CMP_EPSILON);
-		CHECK(ABS(tc_entity_1->transform.origin[0] - 1.) <= CMP_EPSILON);
-		CHECK(ABS(tc_entity_2->transform.origin[0] - 1.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_0->origin[0] - 1.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_1->origin[0] - 1.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_2->origin[0] - 1.) <= CMP_EPSILON);
 	}
 
 	{
@@ -257,16 +257,16 @@ TEST_CASE("[Modules][ECS] Test HierarchicalStorage.") {
 		const TransformComponent *tc_entity_0 = std::as_const(transform_storage).get(0, Space::GLOBAL);
 
 		// Test global world space.
-		CHECK(ABS(tc_entity_0->transform.origin[0] - 1.) <= CMP_EPSILON);
-		CHECK(ABS(tc_entity_1->transform.origin[0] - 2.) <= CMP_EPSILON);
-		CHECK(ABS(tc_entity_2->transform.origin[0] - 3.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_0->origin[0] - 1.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_1->origin[0] - 2.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_2->origin[0] - 3.) <= CMP_EPSILON);
 	}
 
 	// Test update local transform bia `get`.
 	{
 		{
 			TransformComponent *tc_entity_0 = transform_storage.get(0);
-			tc_entity_0->transform = Transform(Basis(), Vector3(3.0, 0., 0.));
+			*tc_entity_0 = Transform(Basis(), Vector3(3.0, 0., 0.));
 		}
 
 		// Flush the above change.
@@ -277,9 +277,9 @@ TEST_CASE("[Modules][ECS] Test HierarchicalStorage.") {
 		const TransformComponent *tc_entity_0 = std::as_const(transform_storage).get(0, Space::GLOBAL);
 
 		// Test global world space.
-		CHECK(ABS(tc_entity_0->transform.origin[0] - 3.) <= CMP_EPSILON);
-		CHECK(ABS(tc_entity_1->transform.origin[0] - 4.) <= CMP_EPSILON);
-		CHECK(ABS(tc_entity_2->transform.origin[0] - 5.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_0->origin[0] - 3.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_1->origin[0] - 4.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_2->origin[0] - 5.) <= CMP_EPSILON);
 
 		CHECK(transform_storage.is_changed(0));
 		CHECK(transform_storage.is_changed(1));
@@ -292,7 +292,7 @@ TEST_CASE("[Modules][ECS] Test HierarchicalStorage.") {
 	{
 		{
 			TransformComponent *tc_entity_2 = transform_storage.get(2, Space::GLOBAL);
-			tc_entity_2->transform = Transform(Basis(), Vector3(7.0, 0., 0.));
+			*tc_entity_2 = Transform(Basis(), Vector3(7.0, 0., 0.));
 		}
 
 		// Flush the above change.
@@ -304,10 +304,10 @@ TEST_CASE("[Modules][ECS] Test HierarchicalStorage.") {
 		const TransformComponent *tc_entity_0 = std::as_const(transform_storage).get(0, Space::GLOBAL);
 
 		// Test global world space.
-		CHECK(ABS(tc_entity_0->transform.origin[0] - 3.) <= CMP_EPSILON);
-		CHECK(ABS(tc_entity_1->transform.origin[0] - 4.) <= CMP_EPSILON);
-		CHECK(ABS(tc_entity_2->transform.origin[0] - 7.) <= CMP_EPSILON);
-		CHECK(ABS(tc_entity_2_local->transform.origin[0] - 3.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_0->origin[0] - 3.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_1->origin[0] - 4.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_2->origin[0] - 7.) <= CMP_EPSILON);
+		CHECK(ABS(tc_entity_2_local->origin[0] - 3.) <= CMP_EPSILON);
 
 		CHECK(transform_storage.is_changed(0) == false);
 		CHECK(transform_storage.is_changed(1) == false);
@@ -331,9 +331,9 @@ TEST_CASE("[Modules][ECS] Test HierarchicalStorage.") {
 		const TransformComponent *tc_entity_0 = std::as_const(transform_storage).get(0, Space::GLOBAL);
 
 		// Test global world space.
-		CHECK(ABS(tc_entity_0->transform.origin[0] - 3.) <= CMP_EPSILON); // Root
-		CHECK(ABS(tc_entity_2->transform.origin[0] - 6.) <= CMP_EPSILON); // Child of `Entity0`.
-		CHECK(ABS(tc_entity_1->transform.origin[0] - 1.) <= CMP_EPSILON); // Root
+		CHECK(ABS(tc_entity_0->origin[0] - 3.) <= CMP_EPSILON); // Root
+		CHECK(ABS(tc_entity_2->origin[0] - 6.) <= CMP_EPSILON); // Child of `Entity0`.
+		CHECK(ABS(tc_entity_1->origin[0] - 1.) <= CMP_EPSILON); // Root
 
 		CHECK(transform_storage.is_changed(0) == false);
 		CHECK(transform_storage.is_changed(1));

--- a/tests/test_ecs_system.h
+++ b/tests/test_ecs_system.h
@@ -74,7 +74,7 @@ namespace godex_tests_system {
 
 void test_system_tag(Query<TransformComponent, const TagTestComponent> &p_query) {
 	for (auto [transform, component] : p_query) {
-		transform->transform.origin.x += 100.0;
+		transform->origin.x += 100.0;
 	}
 }
 
@@ -161,9 +161,9 @@ TEST_CASE("[Modules][ECS] Test system and query") {
 
 	const Storage<const TransformComponent> *storage = world.get_storage<const TransformComponent>();
 
-	const Vector3 entity_1_origin = storage->get(entity_1)->transform.origin;
-	const Vector3 entity_2_origin = storage->get(entity_2)->transform.origin;
-	const Vector3 entity_3_origin = storage->get(entity_3)->transform.origin;
+	const Vector3 entity_1_origin = storage->get(entity_1)->origin;
+	const Vector3 entity_2_origin = storage->get(entity_2)->origin;
+	const Vector3 entity_3_origin = storage->get(entity_3)->origin;
 
 	// This entity is expected to change.
 	CHECK(ABS(entity_1_origin.x - 300.0) <= CMP_EPSILON);
@@ -245,9 +245,9 @@ TEST_CASE("[Modules][ECS] Test dynamic system using a script.") {
 	{
 		const Storage<const TransformComponent> *storage = world.get_storage<const TransformComponent>();
 
-		const Vector3 entity_1_origin = storage->get(entity_1)->transform.origin;
-		const Vector3 entity_2_origin = storage->get(entity_2)->transform.origin;
-		const Vector3 entity_3_origin = storage->get(entity_3)->transform.origin;
+		const Vector3 entity_1_origin = storage->get(entity_1)->origin;
+		const Vector3 entity_2_origin = storage->get(entity_2)->origin;
+		const Vector3 entity_3_origin = storage->get(entity_3)->origin;
 
 		// This entity is expected to change.
 		CHECK(ABS(entity_1_origin.x - 300.0) <= CMP_EPSILON);
@@ -294,14 +294,14 @@ void test_sub_pipeline_execute(World *p_world, Pipeline *p_pipeline) {
 
 void test_system_transform_add_x(Query<TransformComponent> &p_query) {
 	for (auto [transform] : p_query) {
-		transform->transform.origin.x += 100.0;
+		transform->origin.x += 100.0;
 	}
 }
 
 void test_move_root(Query<EntityID, TransformComponent> &p_query) {
 	for (auto [entity, transform] : p_query) {
 		if (entity == EntityID(0)) {
-			transform->transform.origin.x += 1.0;
+			transform->origin.x += 1.0;
 			return;
 		}
 	}
@@ -310,7 +310,7 @@ void test_move_root(Query<EntityID, TransformComponent> &p_query) {
 void test_move_1_global(Query<EntityID, TransformComponent> &p_query) {
 	for (auto [entity, transform] : p_query.space(Space::GLOBAL)) {
 		if (entity == EntityID(1)) {
-			transform->transform.origin.x = 6.0;
+			transform->origin.x = 6.0;
 			return;
 		}
 	}
@@ -361,7 +361,7 @@ TEST_CASE("[Modules][ECS] Test dynamic system with sub pipeline C++.") {
 		// since we are dispatching the main pipeline 2 times the
 		// `test_system_transform_add_x` add 100, four times.
 		const TransformComponent *comp = world.get_storage<TransformComponent>()->get(entity_1);
-		CHECK(ABS(comp->transform.origin.x - 400.0) <= CMP_EPSILON);
+		CHECK(ABS(comp->origin.x - 400.0) <= CMP_EPSILON);
 	}
 
 	{
@@ -373,7 +373,7 @@ TEST_CASE("[Modules][ECS] Test dynamic system with sub pipeline C++.") {
 
 		// Verify the execution is properly done by making sure the value is 1000.
 		const TransformComponent *comp = world.get_storage<TransformComponent>()->get(entity_1);
-		CHECK(ABS(comp->transform.origin.x - 1000.0) <= CMP_EPSILON);
+		CHECK(ABS(comp->origin.x - 1000.0) <= CMP_EPSILON);
 	}
 }
 
@@ -574,13 +574,13 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		// Check local transform.
 		{
 			const TransformComponent *entity_2_transform = world.get_storage<TransformComponent>()->get(entity_2);
-			CHECK(ABS(entity_2_transform->transform.origin.x - 1.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform->origin.x - 1.0) <= CMP_EPSILON);
 		}
 
 		// Check global transform
 		{
 			const TransformComponent *entity_2_transform = world.get_storage<TransformComponent>()->get(entity_2, Space::GLOBAL);
-			CHECK(ABS(entity_2_transform->transform.origin.x - 3.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform->origin.x - 3.0) <= CMP_EPSILON);
 		}
 
 		pipeline.dispatch(&world);
@@ -588,13 +588,13 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		// Check local transform after root motion.
 		{
 			const TransformComponent *entity_2_transform = world.get_storage<TransformComponent>()->get(entity_2);
-			CHECK(ABS(entity_2_transform->transform.origin.x - 1.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform->origin.x - 1.0) <= CMP_EPSILON);
 		}
 
 		// Check global transform after root motion.
 		{
 			const TransformComponent *entity_2_transform = world.get_storage<TransformComponent>()->get(entity_2, Space::GLOBAL);
-			CHECK(ABS(entity_2_transform->transform.origin.x - 4.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform->origin.x - 4.0) <= CMP_EPSILON);
 		}
 	}
 
@@ -614,7 +614,7 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		// Check local transform before motion.
 		{
 			const TransformComponent *entity_1_transform = world.get_storage<TransformComponent>()->get(entity_1);
-			CHECK(ABS(entity_1_transform->transform.origin.x - 1.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_1_transform->origin.x - 1.0) <= CMP_EPSILON);
 		}
 
 		// Dispatch the pipeline, so to move the `Entity_1` globally.
@@ -628,25 +628,25 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		// `Entity 0` din't move.
 		{
 			const TransformComponent *entity_0_transform = world.get_storage<TransformComponent>()->get(entity_0);
-			CHECK(ABS(entity_0_transform->transform.origin.x - 2.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_0_transform->origin.x - 2.0) <= CMP_EPSILON);
 		}
 
 		// `Entity 1` moved globally to 6, so check local and global position:
 		{
 			const TransformComponent *entity_1_transform_l = world.get_storage<TransformComponent>()->get(entity_1);
-			CHECK(ABS(entity_1_transform_l->transform.origin.x - 4.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_1_transform_l->origin.x - 4.0) <= CMP_EPSILON);
 
 			const TransformComponent *entity_1_transform_g = world.get_storage<TransformComponent>()->get(entity_1, Space::GLOBAL);
-			CHECK(ABS(entity_1_transform_g->transform.origin.x - 6.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_1_transform_g->origin.x - 6.0) <= CMP_EPSILON);
 		}
 
 		// `Entity 2` moved cause of the parent motion.
 		{
 			const TransformComponent *entity_2_transform_l = world.get_storage<TransformComponent>()->get(entity_2);
-			CHECK(ABS(entity_2_transform_l->transform.origin.x - 1.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform_l->origin.x - 1.0) <= CMP_EPSILON);
 
 			const TransformComponent *entity_2_transform_g = world.get_storage<TransformComponent>()->get(entity_2, Space::GLOBAL);
-			CHECK(ABS(entity_2_transform_g->transform.origin.x - 7.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform_g->origin.x - 7.0) <= CMP_EPSILON);
 		}
 	}
 
@@ -672,26 +672,26 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		// `Entity 0` din't move.
 		{
 			const TransformComponent *entity_0_transform = world.get_storage<TransformComponent>()->get(entity_0);
-			CHECK(ABS(entity_0_transform->transform.origin.x - 2.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_0_transform->origin.x - 2.0) <= CMP_EPSILON);
 		}
 
 		// `Entity 1` it's not root, and it's relative to itself: local and
 		// global are equals.
 		{
 			const TransformComponent *entity_1_transform_l = world.get_storage<TransformComponent>()->get(entity_1);
-			CHECK(ABS(entity_1_transform_l->transform.origin.x - 4.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_1_transform_l->origin.x - 4.0) <= CMP_EPSILON);
 
 			const TransformComponent *entity_1_transform_g = world.get_storage<TransformComponent>()->get(entity_1, Space::GLOBAL);
-			CHECK(ABS(entity_1_transform_g->transform.origin.x - 4.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_1_transform_g->origin.x - 4.0) <= CMP_EPSILON);
 		}
 
 		// `Entity 2` moved cause of the parent hierarchy change.
 		{
 			const TransformComponent *entity_2_transform_l = world.get_storage<TransformComponent>()->get(entity_2);
-			CHECK(ABS(entity_2_transform_l->transform.origin.x - 1.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform_l->origin.x - 1.0) <= CMP_EPSILON);
 
 			const TransformComponent *entity_2_transform_g = world.get_storage<TransformComponent>()->get(entity_2, Space::GLOBAL);
-			CHECK(ABS(entity_2_transform_g->transform.origin.x - 5.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform_g->origin.x - 5.0) <= CMP_EPSILON);
 		}
 	}
 
@@ -706,16 +706,16 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		// Check `Entity 0` transform.
 		{
 			const TransformComponent *entity_0_transform_l = world.get_storage<TransformComponent>()->get(entity_0);
-			CHECK(ABS(entity_0_transform_l->transform.origin.x - 2.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_0_transform_l->origin.x - 2.0) <= CMP_EPSILON);
 
 			const TransformComponent *entity_0_transform_g = world.get_storage<TransformComponent>()->get(entity_0, Space::GLOBAL);
-			CHECK(ABS(entity_0_transform_g->transform.origin.x - 2.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_0_transform_g->origin.x - 2.0) <= CMP_EPSILON);
 		}
 
 		// Check `Entity 1` transform.
 		{
 			const TransformComponent *entity_1_transform = world.get_storage<TransformComponent>()->get(entity_1, Space::GLOBAL);
-			CHECK(ABS(entity_1_transform->transform.origin.x - 4.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_1_transform->origin.x - 4.0) <= CMP_EPSILON);
 		}
 
 		pipeline.dispatch(&world);
@@ -727,16 +727,16 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		// Make sure `Entity 0` moved.
 		{
 			const TransformComponent *entity_0_transform_l = world.get_storage<TransformComponent>()->get(entity_0);
-			CHECK(ABS(entity_0_transform_l->transform.origin.x - 3.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_0_transform_l->origin.x - 3.0) <= CMP_EPSILON);
 
 			const TransformComponent *entity_0_transform_g = world.get_storage<TransformComponent>()->get(entity_0, Space::GLOBAL);
-			CHECK(ABS(entity_0_transform_g->transform.origin.x - 3.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_0_transform_g->origin.x - 3.0) <= CMP_EPSILON);
 		}
 
 		// Make sure `Entity 1` din't move.
 		{
 			const TransformComponent *entity_1_transform = world.get_storage<TransformComponent>()->get(entity_1, Space::GLOBAL);
-			CHECK(ABS(entity_1_transform->transform.origin.x - 4.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_1_transform->origin.x - 4.0) <= CMP_EPSILON);
 		}
 	}
 
@@ -779,10 +779,10 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		// Make sure `Entity 2` initial position.
 		{
 			const TransformComponent *entity_2_transform_l = world.get_storage<TransformComponent>()->get(entity_2);
-			CHECK(ABS(entity_2_transform_l->transform.origin.x - 1.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform_l->origin.x - 1.0) <= CMP_EPSILON);
 
 			const TransformComponent *entity_2_transform_g = world.get_storage<TransformComponent>()->get(entity_2, Space::GLOBAL);
-			CHECK(ABS(entity_2_transform_g->transform.origin.x - 5.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform_g->origin.x - 5.0) <= CMP_EPSILON);
 		}
 
 		pipeline.dispatch(&world);
@@ -794,16 +794,16 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		// Make sure `Entity 1` didn't move.
 		{
 			const TransformComponent *entity_1_transform_l = world.get_storage<TransformComponent>()->get(entity_1);
-			CHECK(ABS(entity_1_transform_l->transform.origin.x - 4.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_1_transform_l->origin.x - 4.0) <= CMP_EPSILON);
 		}
 
 		// Make sure `Entity 2` moved.
 		{
 			const TransformComponent *entity_2_transform_l = world.get_storage<TransformComponent>()->get(entity_2);
-			CHECK(ABS(entity_2_transform_l->transform.origin.x - 6.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform_l->origin.x - 6.0) <= CMP_EPSILON);
 
 			const TransformComponent *entity_2_transform_g = world.get_storage<TransformComponent>()->get(entity_2, Space::GLOBAL);
-			CHECK(ABS(entity_2_transform_g->transform.origin.x - 10.0) <= CMP_EPSILON);
+			CHECK(ABS(entity_2_transform_g->origin.x - 10.0) <= CMP_EPSILON);
 		}
 	}
 }
@@ -950,7 +950,7 @@ TEST_CASE("[Modules][ECS] Test fetch changed from dynamic system.") {
 	// Dispatch 1 time.
 	pipeline.dispatch(&world);
 
-	CHECK(ABS(world.get_storage<TransformComponent>()->get(entity_1)->transform.origin.x - 100.0) <= CMP_EPSILON);
+	CHECK(ABS(world.get_storage<TransformComponent>()->get(entity_1)->origin.x - 100.0) <= CMP_EPSILON);
 }
 } // namespace godex_tests_system
 

--- a/tests/test_ecs_world.h
+++ b/tests/test_ecs_world.h
@@ -43,7 +43,7 @@ TEST_CASE("[Modules][ECS] Test world") {
 	const TransformComponent *transform_from_storage = storage->get(entity_1);
 
 	// Check the add component has the exact same data as the stored one.
-	CHECK((entity_1_transform_component.transform.origin - transform_from_storage->transform.origin).length() < CMP_EPSILON);
+	CHECK((entity_1_transform_component.origin - transform_from_storage->origin).length() < CMP_EPSILON);
 }
 
 TEST_CASE("[Modules][ECS] Test storage script component") {
@@ -223,7 +223,7 @@ TEST_CASE("[Modules][ECS] Test WorldECS runtime API create entity from prefab.")
 	Entity3D entity_prefab;
 
 	Dictionary defaults;
-	defaults["transform"] = Transform(Basis(), Vector3(10.0, 0.0, 0.0));
+	defaults["origin"] = Vector3(10.0, 0.0, 0.0);
 	entity_prefab.add_component("TransformComponent", defaults);
 
 	const uint32_t entity_id = world.create_entity_from_prefab(&entity_prefab);
@@ -242,7 +242,7 @@ TEST_CASE("[Modules][ECS] Test WorldECS runtime API create entity from prefab.")
 	TransformComponent *transf = godex::unwrap_component<TransformComponent>(comp);
 
 	// Make sure the default is also set.
-	CHECK(ABS(transf->transform.origin.x - 10) <= CMP_EPSILON);
+	CHECK(ABS(transf->origin.x - 10) <= CMP_EPSILON);
 }
 
 TEST_CASE("[Modules][ECS] Test WorldECS runtime API fetch databags.") {


### PR DESCRIPTION
# 1. Transform syntax improved
Now the `TransformComponent` inherit `Transform`, so it's possible to use it exactly like a transform. This mean that to access the transform it's not necessary to write `transform->transform.origin`, but it's enough write `transform->origin`.
**Before**
```c++
void my_system(Query<TransformComponent> &p_q){
  for(auto [transform] : p_q){
    print(transform->transform.origin);
  }
}
```
**Now**
```c++
void my_system(Query<TransformComponent> &p_q){
  for(auto [transform] : p_q){
    print(transform->origin);
  }
}
```

# 2. Transform editor improved
The `TransformComopnent` is now exposing:
- Origin
- Rotation
- Scale
![ezgif com-gif-maker(2)](https://user-images.githubusercontent.com/8342599/118398444-f775c580-b658-11eb-88a4-a845f5de9df9.gif)


# 3. Implemented Depot
With the introduction of `ComponentDepot`, is now possible to store the component data inside the component itself, when not inside the `World`.
Before the component could not be created anywhere else but inside the `World`, so it was necessary to store the data inside a `Dictionary`. With the depot is now possible to spawn the component outside the world, and we can use the component itself to store the data. This is used by the node `Entity3D` and `Entity2D` to hold the information in editor.