### PR TITLE
System bundle 1/n

### DIFF
--- a/ecs.cpp
+++ b/ecs.cpp
@@ -109,6 +109,10 @@ void ECS::__static_destructor() {
 	databags.reset();
 	databags_info.reset();
 
+	// Clear the system bundles static data.
+	system_bundles.reset();
+	system_bundles_info.reset();
+
 	// Clear the systems static data.
 	systems.reset();
 	systems_info.reset();

--- a/ecs.h
+++ b/ecs.h
@@ -57,9 +57,26 @@ struct DatabagInfo {
 	DataAccessorFuncs accessor_funcs;
 };
 
+struct Dependency {
+	bool execute_before;
+	StringName system_name;
+};
+
+enum Phase {
+	PHASE_CONFIG,
+	PHASE_INPUT,
+	PHASE_PRE_PROCESS,
+	PHASE_PROCESS,
+	PHASE_POST_PROCESS,
+};
+
 class SystemInfo {
 	friend class ECS;
+	friend class SystemBundleInfo;
 
+	godex::system_id id;
+	Phase phase = PHASE_PROCESS;
+	LocalVector<Dependency> dependencies;
 	String description;
 
 	// Only one of those is assigned (depending on the system type).
@@ -68,7 +85,26 @@ class SystemInfo {
 	func_temporary_system_execute temporary_exec = nullptr;
 
 public:
+	godex::system_id get_id() const;
+	SystemInfo &set_phase(Phase p_phase);
 	SystemInfo &set_description(const String &p_description);
+	SystemInfo &after(const StringName &p_system_name);
+	SystemInfo &before(const StringName &p_system_name);
+};
+
+class SystemBundleInfo {
+	friend class ECS;
+
+	String description;
+	LocalVector<godex::system_id> systems;
+	/// Bundle dependencies.
+	LocalVector<Dependency> dependencies;
+
+public:
+	SystemBundleInfo &set_description(const String &p_description);
+	SystemBundleInfo &after(const StringName &p_system_name);
+	SystemBundleInfo &before(const StringName &p_system_name);
+	SystemBundleInfo &add(const SystemInfo &p_system_info);
 };
 
 typedef void (*func_notify_static_destructor)();
@@ -101,6 +137,9 @@ private:
 
 	static LocalVector<StringName> systems;
 	static LocalVector<SystemInfo> systems_info;
+
+	static LocalVector<StringName> system_bundles;
+	static LocalVector<SystemBundleInfo> system_bundles_info;
 
 	// Used to keep track of types that need static memory destruction.
 	static LocalVector<func_notify_static_destructor> notify_static_destructor;
@@ -183,6 +222,11 @@ public:
 	static bool unsafe_databag_get_by_index(godex::databag_id p_databag_id, const void *p_databag, uint32_t p_index, Variant &r_data);
 	static void unsafe_databag_call(godex::databag_id p_databag_id, void *p_databag, const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error);
 
+	// ~~ SystemBundle ~~
+	static SystemBundleInfo &register_system_bundle(const StringName &p_name);
+
+	static godex::system_bundle_id get_system_bundle_id(const StringName &p_name);
+
 	// ~~ Systems ~~
 	static SystemInfo &register_system(func_get_system_exe_info p_func_get_exe_info, StringName p_name);
 
@@ -199,7 +243,7 @@ public:
 			name)
 
 	// Register the system and returns the ID.
-	static godex::system_id register_dynamic_system(StringName p_name, const String &p_description = String());
+	static SystemInfo &register_dynamic_system(StringName p_name);
 
 	// This macro save the user the need to pass a `SystemExeInfo`, indeed it wraps
 	// the passed function with a labda function that creates a `SystemExeInfo`.

--- a/ecs_types.h
+++ b/ecs_types.h
@@ -121,6 +121,9 @@ constexpr databag_id DATABAG_NONE = UINT32_MAX;
 typedef uint32_t system_id;
 constexpr system_id SYSTEM_NONE = UINT32_MAX;
 
+typedef uint32_t system_bundle_id;
+constexpr system_bundle_id SYSTEM_BUNDLE_NONE = UINT32_MAX;
+
 /// Shared Component ID, used to identify a component.
 typedef uint32_t SID;
 constexpr SID SID_NONE = UINT32_MAX;

--- a/modules/bullet_physics/register_types.cpp
+++ b/modules/bullet_physics/register_types.cpp
@@ -46,15 +46,15 @@ void register_bullet_physics_types() {
 	ECS::register_component<TorqueImpulse>();
 
 	// Register Base `System`s
-	ECS::register_system(bt_body_config, "BtBodyConfig", "Bullet Physics - Manage the lifetime of the Bodies.");
-	ECS::register_system(bt_area_config, "BtAreaConfig", "Bullet Physics - Manage the lifetime of the Area.");
-	ECS::register_system(bt_apply_forces, "BtApplyForces", "Bullet Physics - Apply `Forces` and `Impulses` to bodies.");
-	ECS::register_system(bt_spaces_step, "BtSpacesStep", "Bullet Physics - Steps the physics spaces.");
-	ECS::register_system(bt_overlap_check, "BtOverlapCheck", "Bullet Physics - Allow the areas to detect ovelapped bodies.");
-	ECS::register_system(bt_body_sync, "BtBodySync", "Bullet Physics - Read the Physics Engine and update the Bodies.");
+	ECS::register_system(bt_body_config, "BtBodyConfig").set_description("Bullet Physics - Manage the lifetime of the Bodies.");
+	ECS::register_system(bt_area_config, "BtAreaConfig").set_description("Bullet Physics - Manage the lifetime of the Area.");
+	ECS::register_system(bt_apply_forces, "BtApplyForces").set_description("Bullet Physics - Apply `Forces` and `Impulses` to bodies.");
+	ECS::register_system(bt_spaces_step, "BtSpacesStep").set_description("Bullet Physics - Steps the physics spaces.");
+	ECS::register_system(bt_overlap_check, "BtOverlapCheck").set_description("Bullet Physics - Allow the areas to detect ovelapped bodies.");
+	ECS::register_system(bt_body_sync, "BtBodySync").set_description("Bullet Physics - Read the Physics Engine and update the Bodies.");
 
 	// Register Walk `System`s
-	ECS::register_system(bt_pawn_walk, "BtPawnWalk", "Bullet Physics - Make the Rigidbody in kinematic mode walk according to Pawn settings.");
+	ECS::register_system(bt_pawn_walk, "BtPawnWalk").set_description("Bullet Physics - Make the Rigidbody in kinematic mode walk according to Pawn settings.");
 
 	// Register gizmos
 	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtBoxGizmo));

--- a/modules/bullet_physics/register_types.cpp
+++ b/modules/bullet_physics/register_types.cpp
@@ -46,15 +46,40 @@ void register_bullet_physics_types() {
 	ECS::register_component<TorqueImpulse>();
 
 	// Register Base `System`s
-	ECS::register_system(bt_body_config, "BtBodyConfig").set_description("Bullet Physics - Manage the lifetime of the Bodies.");
-	ECS::register_system(bt_area_config, "BtAreaConfig").set_description("Bullet Physics - Manage the lifetime of the Area.");
-	ECS::register_system(bt_apply_forces, "BtApplyForces").set_description("Bullet Physics - Apply `Forces` and `Impulses` to bodies.");
-	ECS::register_system(bt_spaces_step, "BtSpacesStep").set_description("Bullet Physics - Steps the physics spaces.");
-	ECS::register_system(bt_overlap_check, "BtOverlapCheck").set_description("Bullet Physics - Allow the areas to detect ovelapped bodies.");
-	ECS::register_system(bt_body_sync, "BtBodySync").set_description("Bullet Physics - Read the Physics Engine and update the Bodies.");
+	ECS::register_system_bundle("BulletPhysics")
+			.set_description("System that allow to use the Bullet physics components.")
+			.add(ECS::register_system(bt_body_config, "BtBodyConfig")
+							.set_phase(PHASE_CONFIG)
+							.set_description("Bullet Physics - Manage the lifetime of the Bodies."))
+
+			.add(ECS::register_system(bt_area_config, "BtAreaConfig")
+							.set_phase(PHASE_CONFIG)
+							.set_description("Bullet Physics - Manage the lifetime of the Area."))
+
+			.add(ECS::register_system(bt_apply_forces, "BtApplyForces")
+							.set_phase(PHASE_PROCESS)
+							.set_description("Bullet Physics - Apply `Forces` and `Impulses` to bodies.")
+							.after("CallPhysicsProcess"))
+
+			.add(ECS::register_system(bt_spaces_step, "BtSpacesStep")
+							.set_phase(PHASE_PROCESS)
+							.set_description("Bullet Physics - Steps the physics spaces.")
+							.after("BtApplyForces"))
+
+			.add(ECS::register_system(bt_overlap_check, "BtOverlapCheck")
+							.set_phase(PHASE_POST_PROCESS)
+							.set_description("Bullet Physics - Allow the areas to detect ovelapped bodies."))
+
+			.add(ECS::register_system(bt_body_sync, "BtBodySync")
+							.set_phase(PHASE_POST_PROCESS)
+							.set_description("Bullet Physics - Read the Physics Engine and update the Bodies."));
 
 	// Register Walk `System`s
-	ECS::register_system(bt_pawn_walk, "BtPawnWalk").set_description("Bullet Physics - Make the Rigidbody in kinematic mode walk according to Pawn settings.");
+	ECS::register_system(bt_pawn_walk, "BtPawnWalk")
+			.set_phase(PHASE_PROCESS)
+			.set_description("Bullet Physics - Make the Rigidbody in kinematic mode walk according to Pawn settings.")
+			.after("BtApplyForces")
+			.before("BtSpacesStep");
 
 	// Register gizmos
 	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(BtBoxGizmo));

--- a/modules/godot/nodes/ecs_utilities.cpp
+++ b/modules/godot/nodes/ecs_utilities.cpp
@@ -565,7 +565,7 @@ void EditorEcs::register_dynamic_systems() {
 	load_systems();
 
 	for (uint32_t i = 0; i < systems.size(); i += 1) {
-		systems[i]->id = ECS::register_dynamic_system(system_names[i]);
+		systems[i]->id = ECS::register_dynamic_system(system_names[i]).get_id();
 		systems[i]->prepare(
 				ECS::get_dynamic_system_info(systems[i]->id),
 				systems[i]->id);

--- a/modules/godot/register_types.cpp
+++ b/modules/godot/register_types.cpp
@@ -91,19 +91,40 @@ void register_godot_types() {
 	ECS::register_databag<InputDatabag>();
 
 	// Engine
-	ECS::register_system(call_physics_process, "CallPhysicsProcess").set_description("Updates the Godot Nodes (2D/3D) transform and fetches the events from the physics engine.");
 
 	// Rendering
-	ECS::register_system(scenario_manager_system, "ScenarioManagerSystem").set_description("Compatibility layer that allow to read the main window scenario and put in the ECS lifecycle; so that `MeshComponent` can properly show the mesh.");
-	ECS::register_system(mesh_updater_system, "MeshUpdaterSystem").set_description("Handles the mesh lifetime. This is required if you want to use `MeshComponent`");
-	ECS::register_system(mesh_transform_updater_system, "MeshTransformUpdaterSystem").set_description("Handles the mesh transformation. This is required if you want to use `MeshComponent`");
+	ECS::register_system_bundle("Rendering3D")
+			.set_description("3D Rendering mechanism.")
+			.add(ECS::register_system(scenario_manager_system, "ScenarioManagerSystem")
+							.set_phase(PHASE_CONFIG)
+							.set_description("Compatibility layer that allow to read the main window scenario and put in the ECS lifecycle; so that `MeshComponent` can properly show the mesh."))
+
+			.add(ECS::register_system(mesh_updater_system, "MeshUpdaterSystem")
+							.set_phase(PHASE_POST_PROCESS)
+							.set_description("Updates the VisualServer with mesh component data"))
+
+			.add(ECS::register_system(mesh_transform_updater_system, "MeshTransformUpdaterSystem")
+							.set_phase(PHASE_POST_PROCESS)
+							.set_description("Updates the VisualServer mesh transforms."));
 
 	// Physics 3D
 	{
-		const godex::system_id id = ECS::register_dynamic_system("PhysicsSystemDispatcher", "System that dispatches the specified pipeline at fixed rate. The rate is defined by `Physics Hz` in the project settings.");
-		create_physics_system_dispatcher(ECS::get_dynamic_system_info(id));
+		const SystemInfo &system_info = ECS::register_dynamic_system("PhysicsSystemDispatcher")
+												.set_phase(PHASE_PROCESS)
+												.set_description("System that dispatches the specified pipeline at fixed rate. The rate is defined by `Physics Hz` in the project settings.");
+		create_physics_system_dispatcher(ECS::get_dynamic_system_info(system_info.get_id()));
 	}
-	ECS::register_system(step_physics_server_3d, "StepPhysicsServer3D").set_description("Steps the PhysicsServer3D.");
+
+	ECS::register_system_bundle("NodeSystemPhysics")
+			.set_description("Handles the godot PhysicsServer stepping. You need to add this SystemBundle if you want to use the Godot Physics Server.")
+			.add(ECS::register_system(call_physics_process, "CallPhysicsProcess")
+							.set_phase(PHASE_PROCESS)
+							.set_description("Updates the Godot Nodes (2D/3D) transform and fetches the events from the physics engine."))
+
+			.add(ECS::register_system(step_physics_server_3d, "StepPhysicsServer3D")
+							.set_phase(PHASE_PROCESS)
+							.set_description("Steps the PhysicsServer3D.")
+							.after("CallPhysicsProcess"));
 
 	ClassDB::register_class<SharedComponentResource>();
 }

--- a/modules/godot/register_types.cpp
+++ b/modules/godot/register_types.cpp
@@ -91,19 +91,19 @@ void register_godot_types() {
 	ECS::register_databag<InputDatabag>();
 
 	// Engine
-	ECS::register_system(call_physics_process, "CallPhysicsProcess", "Updates the Godot Nodes (2D/3D) transform and fetches the events from the physics engine.");
+	ECS::register_system(call_physics_process, "CallPhysicsProcess").set_description("Updates the Godot Nodes (2D/3D) transform and fetches the events from the physics engine.");
 
 	// Rendering
-	ECS::register_system(scenario_manager_system, "ScenarioManagerSystem", "Compatibility layer that allow to read the main window scenario and put in the ECS lifecycle; so that `MeshComponent` can properly show the mesh.");
-	ECS::register_system(mesh_updater_system, "MeshUpdaterSystem", "Handles the mesh lifetime. This is required if you want to use `MeshComponent`");
-	ECS::register_system(mesh_transform_updater_system, "MeshTransformUpdaterSystem", "Handles the mesh transformation. This is required if you want to use `MeshComponent`");
+	ECS::register_system(scenario_manager_system, "ScenarioManagerSystem").set_description("Compatibility layer that allow to read the main window scenario and put in the ECS lifecycle; so that `MeshComponent` can properly show the mesh.");
+	ECS::register_system(mesh_updater_system, "MeshUpdaterSystem").set_description("Handles the mesh lifetime. This is required if you want to use `MeshComponent`");
+	ECS::register_system(mesh_transform_updater_system, "MeshTransformUpdaterSystem").set_description("Handles the mesh transformation. This is required if you want to use `MeshComponent`");
 
 	// Physics 3D
 	{
 		const godex::system_id id = ECS::register_dynamic_system("PhysicsSystemDispatcher", "System that dispatches the specified pipeline at fixed rate. The rate is defined by `Physics Hz` in the project settings.");
 		create_physics_system_dispatcher(ECS::get_dynamic_system_info(id));
 	}
-	ECS::register_system(step_physics_server_3d, "StepPhysicsServer3D", "Steps the PhysicsServer3D.");
+	ECS::register_system(step_physics_server_3d, "StepPhysicsServer3D").set_description("Steps the PhysicsServer3D.");
 
 	ClassDB::register_class<SharedComponentResource>();
 }

--- a/tests/test_ecs_pipeline.h
+++ b/tests/test_ecs_pipeline.h
@@ -114,7 +114,9 @@ TEST_CASE("[Modules][ECS] Test pipeline get_systems_dependencies") {
 }
 
 TEST_CASE("[Modules][ECS] Test pipeline get_systems_dependencies from a dispatcher.") {
-	const godex::system_id sub_dispatcher_system_id = ECS::register_dynamic_system("SubDispatcherSystemTest", "Unit tests system.");
+	const godex::system_id sub_dispatcher_system_id = ECS::register_dynamic_system("SubDispatcherSystemTest")
+															  .set_description("Unit tests system.")
+															  .get_id();
 
 	Pipeline pipeline;
 	Pipeline sub_pipeline;

--- a/tests/test_ecs_system.h
+++ b/tests/test_ecs_system.h
@@ -222,7 +222,7 @@ TEST_CASE("[Modules][ECS] Test dynamic system using a script.") {
 	}
 
 	// Build dynamic query.
-	const uint32_t system_id = ECS::register_dynamic_system("TestDynamicSystem.gd");
+	const uint32_t system_id = ECS::register_dynamic_system("TestDynamicSystem.gd").get_id();
 	godex::DynamicSystemInfo *dynamic_system_info = ECS::get_dynamic_system_info(system_id);
 	dynamic_system_info->with_component(TransformComponent::get_component_id(), true);
 	dynamic_system_info->maybe_component(test_dyn_component_id, true);
@@ -328,7 +328,7 @@ TEST_CASE("[Modules][ECS] Test dynamic system with sub pipeline C++.") {
 	sub_pipeline.add_system(test_system_transform_add_x);
 	sub_pipeline.build();
 
-	const uint32_t sub_pipeline_system_id = ECS::register_dynamic_system("TestSubPipelineExecute");
+	const uint32_t sub_pipeline_system_id = ECS::register_dynamic_system("TestSubPipelineExecute").get_id();
 	godex::DynamicSystemInfo *sub_pipeline_system = ECS::get_dynamic_system_info(sub_pipeline_system_id);
 	sub_pipeline_system->set_target(test_sub_pipeline_execute);
 	// Used internally by the `test_sub_pipeline_execute`.
@@ -454,7 +454,7 @@ TEST_CASE("[Modules][ECS] Test system databag fetch with dynamic query.") {
 	}
 
 	// Build dynamic query.
-	const uint32_t system_id = ECS::register_dynamic_system("TestDatabagDynamicSystem.gd");
+	const uint32_t system_id = ECS::register_dynamic_system("TestDatabagDynamicSystem.gd").get_id();
 	godex::DynamicSystemInfo *dynamic_system_info = ECS::get_dynamic_system_info(system_id);
 	dynamic_system_info->with_databag(TestSystemSubPipeDatabag::get_databag_id(), true);
 	dynamic_system_info->with_component(TransformComponent::get_component_id(), false);
@@ -758,7 +758,7 @@ TEST_CASE("[Modules][ECS] Test system and hierarchy.") {
 		}
 
 		// Build dynamic query.
-		const uint32_t system_id = ECS::register_dynamic_system("TestMoveHierarchySystem.gd");
+		const uint32_t system_id = ECS::register_dynamic_system("TestMoveHierarchySystem.gd").get_id();
 		godex::DynamicSystemInfo *dynamic_system_info = ECS::get_dynamic_system_info(system_id);
 		dynamic_system_info->set_space(Space::GLOBAL);
 		dynamic_system_info->with_component(TransformComponent::get_component_id(), true);
@@ -840,7 +840,7 @@ TEST_CASE("[Modules][ECS] Test Add/remove from dynamic system.") {
 		}
 
 		// Build dynamic query.
-		const uint32_t system_id = ECS::register_dynamic_system("TestSpawnDynamicSystem.gd");
+		const uint32_t system_id = ECS::register_dynamic_system("TestSpawnDynamicSystem.gd").get_id();
 		godex::DynamicSystemInfo *dynamic_system_info = ECS::get_dynamic_system_info(system_id);
 		dynamic_system_info->with_databag(WorldCommands::get_databag_id(), true);
 		dynamic_system_info->with_storage(Test1Component::get_component_id());
@@ -889,7 +889,7 @@ TEST_CASE("[Modules][ECS] Test Add/remove from dynamic system.") {
 		}
 
 		// Build dynamic query.
-		const uint32_t system_id = ECS::register_dynamic_system("TestRemoveDynamicSystem.gd");
+		const uint32_t system_id = ECS::register_dynamic_system("TestRemoveDynamicSystem.gd").get_id();
 		godex::DynamicSystemInfo *dynamic_system_info = ECS::get_dynamic_system_info(system_id);
 		dynamic_system_info->with_databag(WorldCommands::get_databag_id(), true);
 		dynamic_system_info->with_storage(Test1Component::get_component_id());
@@ -934,7 +934,7 @@ TEST_CASE("[Modules][ECS] Test fetch changed from dynamic system.") {
 	}
 
 	// Build dynamic query.
-	const uint32_t system_id = ECS::register_dynamic_system("TestChangedDynamicSystem.gd");
+	const godex::system_id system_id = ECS::register_dynamic_system("TestChangedDynamicSystem.gd").get_id();
 	godex::DynamicSystemInfo *dynamic_system_info = ECS::get_dynamic_system_info(system_id);
 	dynamic_system_info->changed_component(TransformComponent::get_component_id(), true);
 	dynamic_system_info->set_target(target_obj.get_script_instance());
@@ -1054,7 +1054,7 @@ TEST_CASE("[Modules][ECS] Test fetch entity from nodepath, using a dynamic syste
 		}
 
 		// Build dynamic query.
-		const uint32_t system_id = ECS::register_dynamic_system("TestFetchEntityFromNodePath.gd");
+		const uint32_t system_id = ECS::register_dynamic_system("TestFetchEntityFromNodePath.gd").get_id();
 		godex::DynamicSystemInfo *dynamic_system_info = ECS::get_dynamic_system_info(system_id);
 		dynamic_system_info->with_databag(World::get_databag_id(), false);
 		dynamic_system_info->with_component(Test1Component::get_component_id(), true);

--- a/tests/test_ecs_temporary_system.h
+++ b/tests/test_ecs_temporary_system.h
@@ -43,7 +43,7 @@ TEST_CASE("[Modules][ECS] Test temporary system.") {
 }
 
 TEST_CASE("[Modules][ECS] Test registered temporary system.") {
-	ECS::register_temporary_system(temporary_system_1_test, "TemporarySystemTest", "");
+	ECS::register_temporary_system(temporary_system_1_test, "TemporarySystemTest");
 
 	World world;
 	world.create_databag<ExecutionCounter>();


### PR DESCRIPTION
Related to: https://github.com/GodotECS/godex/issues/38

Now the system is registered with the following syntax:
```
ECS::register_system(system_func, "SystemName")
	.set_description("Description goes here");
```
This change was done to support SystemBundle and system dependencies.

----

Implemented the system bundle concept, this is the first commit to move
the pipeline organization from the editor UI to code.

This shift is necessary because the user may not be aware how the systems
must be organized. The developer who implements the systems, will take
care to organize the system order and dependencies. The user will just
need to specify which features needs.
