### PR TITLE
Add scripted System Bundle

### DIFF
--- a/modules/godot/nodes/ecs_utilities.cpp
+++ b/modules/godot/nodes/ecs_utilities.cpp
@@ -171,9 +171,34 @@ uint32_t System::get_current_entity_id() const {
 }
 
 String System::validate_script(Ref<Script> p_script) {
-	ERR_FAIL_COND_V(p_script.is_null(), "Script is null.");
-	ERR_FAIL_COND_V(p_script->is_valid() == false, "Script has some errors.");
-	ERR_FAIL_COND_V("System" != p_script->get_instance_base_type(), "This script is not extending `System`.");
+	if (p_script.is_null()) {
+		return TTR("Script is null.");
+	}
+	if (p_script->is_valid() == false) {
+		return TTR("Script has some errors.");
+	}
+	if ("System" != p_script->get_instance_base_type()) {
+		return TTR("This script is not extending `System`.");
+	}
+	List<MethodInfo> methods;
+	p_script->get_script_method_list(&methods);
+	bool has_prepare = false;
+	bool has_for_each = false;
+	for (List<MethodInfo>::Element *e = methods.front(); e; e = e->next()) {
+		if (e->get().name == "_prepare") {
+			has_prepare = true;
+		}
+		if (e->get().name == "_for_each") {
+			has_for_each = true;
+			// TODO consider add input check, so to notify the user if the system is not valid.
+		}
+	}
+	if (has_prepare == false) {
+		return TTR("This script is not overriding the function `_prepare()`.");
+	}
+	if (has_for_each == false) {
+		return TTR("This script is not overriding the function `_for_each()`.");
+	}
 
 	List<PropertyInfo> properties;
 	p_script->get_script_property_list(&properties);
@@ -235,10 +260,27 @@ void SystemBundle::after(const StringName &p_dependency) {
 }
 
 String SystemBundle::validate_script(Ref<Script> p_script) {
-	ERR_FAIL_COND_V(p_script.is_null(), "Script is null.");
-	ERR_FAIL_COND_V(p_script->is_valid() == false, "Script has some errors.");
-	ERR_FAIL_COND_V("SystemBundle" != p_script->get_instance_base_type(), "This script is not extending `SystemBundle`.");
-	ERR_FAIL_COND_V(p_script->get_method_info("_prepare").name.is_empty(), "This script is not overriding the function `_prepare()`.");
+	if (p_script.is_null()) {
+		return TTR("Script is null.");
+	}
+	if (p_script->is_valid() == false) {
+		return TTR("Script has some errors.");
+	}
+	if ("SystemBundle" != p_script->get_instance_base_type()) {
+		return TTR("This script is not extending `SystemBundle`.");
+	}
+	List<MethodInfo> methods;
+	p_script->get_script_method_list(&methods);
+	bool has_prepare = false;
+	for (List<MethodInfo>::Element *e = methods.front(); e; e = e->next()) {
+		if (e->get().name == "_prepare") {
+			has_prepare = true;
+			break;
+		}
+	}
+	if (has_prepare == false) {
+		return TTR("This script is not overriding the function `_prepare()`.");
+	}
 	// This script is safe to use.
 	return "";
 }
@@ -311,9 +353,15 @@ Vector<StringName> Component::get_spawners() {
 }
 
 String Component::validate_script(Ref<Script> p_script) {
-	ERR_FAIL_COND_V(p_script.is_null(), "Script is null.");
-	ERR_FAIL_COND_V(p_script->is_valid() == false, "Script has some errors.");
-	ERR_FAIL_COND_V("Component" != p_script->get_instance_base_type(), "This script is not extending `Component`.");
+	if (p_script.is_null()) {
+		return TTR("Script is null.");
+	}
+	if (p_script->is_valid() == false) {
+		return TTR("Script has some errors.");
+	}
+	if ("Component" != p_script->get_instance_base_type()) {
+		return TTR("This script is not extending `Component`.");
+	}
 
 	// Make sure doesn't have any function in it.
 	List<MethodInfo> methods;

--- a/modules/godot/nodes/ecs_utilities.h
+++ b/modules/godot/nodes/ecs_utilities.h
@@ -50,7 +50,6 @@ public:
 	void execute_in_phase(Phase p_phase);
 	void execute_after(const StringName &p_system_name);
 	void execute_before(const StringName &p_system_name);
-	void add_to_bundle(const StringName &p_system_name);
 
 	void set_space(Space p_space);
 	void with_databag(uint32_t p_databag_id, Mutability p_mutability);
@@ -67,12 +66,28 @@ public:
 	static String validate_script(Ref<Script> p_script);
 };
 
-class SystemBundle {
+class SystemBundle : public Resource {
+	GDCLASS(SystemBundle, Resource)
+
 	friend class ScriptEcs;
 
-	LocalVector<StringName> systems;
-	//String description;
-	//LocalVector<Dependency> dependencies;
+	bool verified = false;
+	String script_path;
+	String *description = nullptr;
+	LocalVector<StringName> *systems = nullptr;
+	LocalVector<Dependency> *dependencies = nullptr;
+
+	static void _bind_methods();
+	void __fetch_systems(String *r_desc, LocalVector<StringName> *r_systems, LocalVector<Dependency> *r_dependencies);
+	const String &get_script_path() const;
+
+public:
+	void add(const StringName &p_system_name);
+	void with_description(const String &p_desc);
+	void before(const StringName &p_dependency);
+	void after(const StringName &p_dependency);
+
+	static String validate_script(Ref<Script> p_script);
 };
 
 VARIANT_ENUM_CAST(System::Mutability)

--- a/modules/godot/nodes/script_ecs.h
+++ b/modules/godot/nodes/script_ecs.h
@@ -37,7 +37,7 @@ class ScriptEcs : public Object {
 	LocalVector<Ref<System>> systems;
 
 	LocalVector<StringName> system_bundle_names;
-	LocalVector<SystemBundle> system_bundles;
+	LocalVector<Ref<SystemBundle>> system_bundles;
 
 	static ScriptEcs *singleton;
 
@@ -67,7 +67,7 @@ public:
 	// ------------------------------------------------------------------ Databag
 
 	// ----------------------------------------------------------- System Bundles
-	void add_system_to_bundle(const StringName &p_system_name, const StringName &p_system_bundle_name);
+	Ref<SystemBundle> get_script_system_bundle(const StringName &p_name);
 
 	// ------------------------------------------------------------------- System
 	const LocalVector<StringName> &get_script_system_names();
@@ -86,9 +86,11 @@ public:
 	void register_dynamic_components();
 	void register_dynamic_component(Component *p_component);
 	void register_dynamic_systems();
+	void register_dynamic_system_bundles();
 
 private:
 	void reload_script(const String &p_path, const String &p_name, const bool p_force_reload);
+	Ref<SystemBundle> reload_system_bundle(Ref<Script> p_script, const String &p_path, const String &p_name);
 	Ref<System> reload_system(Ref<Script> p_script, const String &p_path, const String &p_name);
 	Ref<Component> reload_component(Ref<Script> p_script, const String &p_path, const String &p_name);
 

--- a/modules/godot/register_types.cpp
+++ b/modules/godot/register_types.cpp
@@ -56,6 +56,7 @@ void register_godot_types() {
 	ClassDB::register_class<Entity2D>();
 	ClassDB::register_class<Component>();
 	ClassDB::register_class<System>();
+	ClassDB::register_class<SystemBundle>();
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Gizmos
 	Components3DGizmoPlugin::get_singleton()->add_component_gizmo(memnew(TransformComponentGizmo));


### PR DESCRIPTION
Add scripted System Bundle. Now it's possible to create a script that extends `SystemBundle`, to define a new bundle directly from the editor.

Improved the script validation. Now it's more precise at reporting script issues.