### PR TITLE
Hide the `parent` property from `Child` component.

### DIFF
--- a/components/child.cpp
+++ b/components/child.cpp
@@ -1,8 +1,7 @@
 #include "child.h"
 
 void Child::_bind_methods() {
-	// TODO don't expose to editor but allow fetch this from scripts.
-	ECS_BIND_PROPERTY(Child, PropertyInfo(Variant::INT, "parent"), parent);
+	ECS_BIND_PROPERTY(Child, PropertyInfo(Variant::INT, "parent", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), parent);
 }
 
 void Child::_get_storage_config(Dictionary &r_dictionary) {


### PR DESCRIPTION
Hide the `parent` property from `Child` component.