### PR TITLE
Add dynamic set and get.

### DIFF
--- a/components/component.h
+++ b/components/component.h
@@ -19,8 +19,8 @@ public:                                                                         
 	ECS_PROPERTY_MAPPER(m_class)                                                       \
 	ECS_METHOD_MAPPER(m_class)                                                         \
 	static void __static_destructor() {                                                \
-		property_map.reset();                                                          \
-		properties.reset();                                                            \
+		static_property_map.reset();                                                   \
+		static_properties.reset();                                                     \
 		setters.reset();                                                               \
 		getters.reset();                                                               \
 		methods_map.reset();                                                           \

--- a/components/dynamic_component.cpp
+++ b/components/dynamic_component.cpp
@@ -63,7 +63,7 @@ StorageBase *DynamicComponentInfo::create_storage() {
 	return nullptr;
 }
 
-void DynamicComponentInfo::static_get_property_list(void *p_self, const DynamicComponentInfo *p_info, List<PropertyInfo> *r_list) {
+void DynamicComponentInfo::get_property_list(void *p_self, const DynamicComponentInfo *p_info, List<PropertyInfo> *r_list) {
 	for (uint32_t i = 0; i < p_info->properties.size(); ++i) {
 		r_list->push_back(p_info->properties[i]);
 	}

--- a/components/dynamic_component.h
+++ b/components/dynamic_component.h
@@ -20,7 +20,7 @@ public:
 
 	// TODO move all this to CPP
 
-	const LocalVector<PropertyInfo> *get_properties() const {
+	const LocalVector<PropertyInfo> *get_static_properties() const {
 		return &properties;
 	}
 
@@ -45,7 +45,7 @@ public:
 	}
 
 public:
-	static void static_get_property_list(void *p_self, const DynamicComponentInfo *p_info, List<PropertyInfo> *r_list);
+	static void get_property_list(void *p_self, const DynamicComponentInfo *p_info, List<PropertyInfo> *r_list);
 
 	static bool static_set(void *p_self, const DynamicComponentInfo *p_info, const StringName &p_name, const Variant &p_data);
 	static bool static_get(const void *p_self, const DynamicComponentInfo *p_info, const StringName &p_name, Variant &r_data);
@@ -72,7 +72,7 @@ public:
 	void __initialize(DynamicComponentInfo *p_info) {
 #ifdef DEBUG_ENABLED
 		CRASH_COND_MSG(p_info == nullptr, "The component info can't be nullptr.");
-		CRASH_COND_MSG(p_info->get_properties()->size() != 0, "The ZeroVariantComponent can't be initiazlized with `DanamicComponentInfo` that has data for more paramenters.");
+		CRASH_COND_MSG(p_info->get_static_properties()->size() != 0, "The ZeroVariantComponent can't be initiazlized with `DanamicComponentInfo` that has data for more paramenters.");
 #endif
 		info = p_info;
 	}
@@ -141,7 +141,7 @@ template <int SIZE>
 void VariantComponent<SIZE>::__initialize(DynamicComponentInfo *p_info) {
 #ifdef DEBUG_ENABLED
 	CRASH_COND_MSG(p_info == nullptr, "The component info can't be nullptr.");
-	CRASH_COND_MSG(p_info->get_properties()->size() != SIZE, "The VariantComponent(size: " + itos(SIZE) + ") got created with a ScriptComponentInfo that has " + itos(p_info->get_properties()->size()) + " parameters, this is not supposed to happen.");
+	CRASH_COND_MSG(p_info->get_static_properties()->size() != SIZE, "The VariantComponent(size: " + itos(SIZE) + ") got created with a ScriptComponentInfo that has " + itos(p_info->get_static_properties()->size()) + " parameters, this is not supposed to happen.");
 #endif
 
 	info = p_info;

--- a/databags/databag.h
+++ b/databags/databag.h
@@ -37,8 +37,8 @@ public:                                                              \
 	ECS_METHOD_MAPPER(m_class)                                       \
                                                                      \
 	static void __static_destructor() {                              \
-		property_map.reset();                                        \
-		properties.reset();                                          \
+		static_property_map.reset();                                 \
+		static_properties.reset();                                   \
 		setters.reset();                                             \
 		getters.reset();                                             \
 		methods_map.reset();                                         \

--- a/ecs.cpp
+++ b/ecs.cpp
@@ -190,12 +190,20 @@ bool ECS::storage_notify_release_write(godex::component_id p_component_id) {
 	return components_info[p_component_id].notify_release_write;
 }
 
-const LocalVector<PropertyInfo> *ECS::get_component_properties(uint32_t p_component_id) {
+const LocalVector<PropertyInfo> *ECS::component_get_static_properties(uint32_t p_component_id) {
 	ERR_FAIL_COND_V_MSG(verify_component_id(p_component_id) == false, nullptr, "The `component_id` is invalid: " + itos(p_component_id));
 	if (components_info[p_component_id].dynamic_component_info != nullptr) {
-		return components_info[p_component_id].dynamic_component_info->get_properties();
+		return components_info[p_component_id].dynamic_component_info->get_static_properties();
 	} else {
-		return components_info[p_component_id].accessor_funcs.get_properties();
+		return components_info[p_component_id].accessor_funcs.get_static_properties();
+	}
+}
+
+void ECS::unsafe_component_get_property_list(godex::component_id p_component_id, void *p_component, List<PropertyInfo> *r_list) {
+	if (components_info[p_component_id].dynamic_component_info != nullptr) {
+		return DynamicComponentInfo::get_property_list(p_component, components_info[p_component_id].dynamic_component_info, r_list);
+	} else {
+		return components_info[p_component_id].accessor_funcs.get_property_list(p_component, r_list);
 	}
 }
 
@@ -272,14 +280,6 @@ void ECS::unsafe_component_call(godex::component_id p_component_id, void *p_comp
 	}
 }
 
-void ECS::unsafe_component_dynamic_get_property_list(godex::component_id p_component_id, void *p_component, List<PropertyInfo> *r_list) {
-	if (components_info[p_component_id].dynamic_component_info != nullptr) {
-		return DynamicComponentInfo::static_get_property_list(p_component, components_info[p_component_id].dynamic_component_info, r_list);
-	} else {
-		return components_info[p_component_id].accessor_funcs.dynamic_get_property_list(p_component, r_list);
-	}
-}
-
 bool ECS::verify_databag_id(godex::databag_id p_id) {
 	return p_id < databags.size();
 }
@@ -345,8 +345,8 @@ void ECS::unsafe_databag_call(
 			r_error);
 }
 
-void ECS::unsafe_databag_dynamic_get_property_list(godex::databag_id p_databag_id, void *p_databag, List<PropertyInfo> *r_list) {
-	databags_info[p_databag_id].accessor_funcs.dynamic_get_property_list(p_databag, r_list);
+void ECS::unsafe_databag_get_property_list(godex::databag_id p_databag_id, void *p_databag, List<PropertyInfo> *r_list) {
+	databags_info[p_databag_id].accessor_funcs.get_property_list(p_databag, r_list);
 }
 
 bool ECS::verify_event_id(godex::event_id p_id) {
@@ -451,8 +451,8 @@ void ECS::unsafe_event_call(godex::event_id p_event_id, void *p_event, const Str
 	events_info[p_event_id].accessor_funcs.call(p_event, p_method, p_args, p_argcount, r_ret, r_error);
 }
 
-void ECS::unsafe_event_dynamic_get_property_list(godex::event_id p_event_id, void *p_event, List<PropertyInfo> *r_list) {
-	events_info[p_event_id].accessor_funcs.dynamic_get_property_list(p_event, r_list);
+void ECS::unsafe_event_get_property_list(godex::event_id p_event_id, void *p_event, List<PropertyInfo> *r_list) {
+	events_info[p_event_id].accessor_funcs.get_property_list(p_event, r_list);
 }
 
 SystemBundleInfo &ECS::register_system_bundle(const StringName &p_name) {

--- a/events/events.h
+++ b/events/events.h
@@ -15,8 +15,8 @@ public:                                                                         
 	ECS_PROPERTY_MAPPER(m_class)                                                      \
 	ECS_METHOD_MAPPER(m_class)                                                        \
 	static void __static_destructor() {                                               \
-		property_map.reset();                                                         \
-		properties.reset();                                                           \
+		static_property_map.reset();                                                  \
+		static_properties.reset();                                                    \
 		setters.reset();                                                              \
 		getters.reset();                                                              \
 		methods_map.reset();                                                          \

--- a/modules/godot/editor_plugins/entity_editor_plugin.cpp
+++ b/modules/godot/editor_plugins/entity_editor_plugin.cpp
@@ -174,6 +174,7 @@ void EntityEditor::create_component_inspector(StringName p_component_name, const
 						}
 						EditorPropertyLayers *editor = memnew(EditorPropertyLayers);
 						editor->setup(lt);
+						prop = editor;
 
 					} else if (e.hint == PROPERTY_HINT_OBJECT_ID) {
 						EditorPropertyObjectID *editor = memnew(EditorPropertyObjectID);

--- a/modules/godot/editor_plugins/entity_editor_plugin.h
+++ b/modules/godot/editor_plugins/entity_editor_plugin.h
@@ -32,7 +32,7 @@ public:
 
 	void create_editors();
 	void update_editors();
-	void create_component_inspector(StringName p_component_name, VBoxContainer *p_container);
+	void create_component_inspector(StringName p_component_name, const Ref<ComponentDepot> &p_depot, VBoxContainer *p_container);
 	void update_component_inspector(StringName p_component_name);
 	void _add_component_pressed(uint32_t p_index);
 	void _remove_component_pressed(StringName p_component_name);

--- a/modules/godot/nodes/ecs_utilities.h
+++ b/modules/godot/nodes/ecs_utilities.h
@@ -134,9 +134,12 @@ public:
 
 	virtual void init(const StringName &p_name) = 0;
 	virtual Dictionary get_properties_data() const = 0;
+
+	virtual void _get_property_list(List<PropertyInfo> *r_list) const = 0;
 };
 
 class StaticComponentDepot : public ComponentDepot {
+	friend class SharedComponentResource;
 	void *component = nullptr;
 	godex::component_id component_id = godex::COMPONENT_NONE;
 
@@ -151,6 +154,7 @@ public:
 	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override;
 
 	virtual Dictionary get_properties_data() const override;
+	virtual void _get_property_list(List<PropertyInfo> *r_list) const;
 };
 
 class ScriptComponentDepot : public ComponentDepot {
@@ -163,6 +167,7 @@ public:
 	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override;
 
 	virtual Dictionary get_properties_data() const override;
+	virtual void _get_property_list(List<PropertyInfo> *r_list) const;
 };
 
 class SharedComponentDepot : public ComponentDepot {
@@ -175,4 +180,5 @@ public:
 	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override;
 
 	virtual Dictionary get_properties_data() const override;
+	virtual void _get_property_list(List<PropertyInfo> *r_list) const;
 };

--- a/modules/godot/nodes/script_ecs.cpp
+++ b/modules/godot/nodes/script_ecs.cpp
@@ -171,7 +171,7 @@ void ScriptEcs::define_editor_default_component_properties() {
 	const StringName entity_2d_name = Entity2D::get_class_static();
 
 	for (godex::component_id id = 0; id < ECS::get_components_count(); id += 1) {
-		const LocalVector<PropertyInfo> *props = ECS::get_component_properties(id);
+		const LocalVector<PropertyInfo> *props = ECS::component_get_static_properties(id);
 		for (uint32_t p = 0; p < props->size(); p += 1) {
 			Variant def = ECS::get_component_property_default(id, (*props)[p].name);
 			ClassDB::set_property_default_value(entity_3d_name, StringName(String(ECS::get_component_name(id)) + "/" + (*props)[p].name), def);

--- a/modules/godot/nodes/shared_component_resource.cpp
+++ b/modules/godot/nodes/shared_component_resource.cpp
@@ -28,15 +28,12 @@ bool SharedComponentResource::_get(const StringName &p_name, Variant &r_property
 	return success;
 }
 
-void SharedComponentResource::_get_property_list(List<PropertyInfo> *p_list) const {
+void SharedComponentResource::_get_property_list(List<PropertyInfo> *r_list) const {
 	ERR_FAIL_COND_MSG(is_init() == false, "This shared component is not init. So you can't use it.");
 	ERR_FAIL_COND_MSG(ECS::is_component_sharable(ECS::get_component_id(component_name)) == false, "This component is not shared, this is not supposed to happen.");
 
-	const godex::component_id id = ECS::get_component_id(component_name);
-	ERR_FAIL_COND(id == godex::COMPONENT_NONE);
-	const LocalVector<PropertyInfo> *properties = ECS::get_component_properties(id);
-	for (uint32_t i = 0; i < properties->size(); i += 1) {
-		p_list->push_back((*properties)[i]);
+	if (depot.is_valid()) {
+		depot->_get_property_list(r_list);
 	}
 }
 

--- a/storage/event_storage.h
+++ b/storage/event_storage.h
@@ -67,7 +67,7 @@ public:
 	}
 
 	virtual Array get_events_array(const String &p_emitter) const override {
-		const LocalVector<PropertyInfo> *props = E::get_properties();
+		const LocalVector<PropertyInfo> *props = E::get_static_properties();
 
 		Array ret;
 		const LocalVector<E> *events = get_events(p_emitter);

--- a/tests/test_ecs_component.h
+++ b/tests/test_ecs_component.h
@@ -21,4 +21,126 @@ TEST_CASE("[Modules][ECS] Test component create pointer.") {
 }
 } // namespace godex_component_test
 
+struct TestDynamicSetGetComponent {
+	COMPONENT(TestDynamicSetGetComponent, DenseVectorStorage);
+
+	static void _bind_methods() {
+		ECS_BIND_PROPERTY(TestDynamicSetGetComponent, PropertyInfo(Variant::BOOL, "enable_color"), enable_color);
+	}
+
+	void _get_property_list(List<PropertyInfo> *r_list) {
+		if (enable_color) {
+			r_list->push_back(PropertyInfo(Variant::COLOR, "color"));
+		}
+	}
+
+	bool _set(const StringName &p_name, const Variant &p_value) {
+		if (enable_color) {
+			if (p_name == SNAME("color")) {
+				meta[SNAME("color")] = p_value;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	bool _get(const StringName &p_name, Variant &r_value) const {
+		if (enable_color) {
+			if (p_name == SNAME("color")) {
+				if (meta.has(SNAME("color"))) {
+					r_value = meta[SNAME("color")];
+				} else {
+					// Default color.
+					r_value = Color(1.0, 0.0, 0.0);
+				}
+				return true;
+			}
+		}
+		return false;
+	}
+
+	bool enable_color = false;
+	Dictionary meta;
+};
+
+namespace godex_component_test {
+TEST_CASE("[Modules][ECS] Test component dynamic set and get.") {
+	ECS::register_component<TestDynamicSetGetComponent>();
+
+	// Create the component using the `unsafe_` functions, so we can also test those.
+	void *component = ECS::new_component(TestDynamicSetGetComponent::get_component_id());
+
+	{
+		List<PropertyInfo> properties;
+		ECS::unsafe_component_get_property_list(
+				TestDynamicSetGetComponent::get_component_id(),
+				component,
+				&properties);
+
+		// By default `enable_color` is set to `false` so we have only one property.
+		CHECK(properties.size() == 1);
+		CHECK(properties[0].name == "enable_color");
+	}
+
+	// Now set `enable_color` to `true`.
+	ECS::unsafe_component_set_by_name(TestDynamicSetGetComponent::get_component_id(), component, SNAME("enable_color"), true);
+
+	{
+		List<PropertyInfo> properties;
+		ECS::unsafe_component_get_property_list(
+				TestDynamicSetGetComponent::get_component_id(),
+				component,
+				&properties);
+
+		// Now `enable_color` is set to `true` so we have two property.
+		CHECK(properties.size() == 2);
+		// And one of those is `color` which is dynamic.
+		CHECK((properties[0].name == "color" || properties[1].name == "color"));
+	}
+
+	{
+		// Get the default color:
+		const Color color = ECS::unsafe_component_get_by_name(
+				TestDynamicSetGetComponent::get_component_id(),
+				component,
+				SNAME("color"));
+
+		CHECK(Math::is_equal_approx(color.r, real_t(1.0)));
+		CHECK(Math::is_equal_approx(color.g, real_t(0.0)));
+		CHECK(Math::is_equal_approx(color.b, real_t(0.0)));
+	}
+
+	{
+		// Try to set `color`
+		ECS::unsafe_component_set_by_name(TestDynamicSetGetComponent::get_component_id(), component, SNAME("color"), Color(0.0, 1.0, 0.0));
+
+		const Color color = ECS::unsafe_component_get_by_name(
+				TestDynamicSetGetComponent::get_component_id(),
+				component,
+				SNAME("color"));
+
+		CHECK(Math::is_equal_approx(color.r, real_t(0.0)));
+		CHECK(Math::is_equal_approx(color.g, real_t(1.0)));
+		CHECK(Math::is_equal_approx(color.b, real_t(0.0)));
+	}
+
+	// Set color enabled to false
+	ECS::unsafe_component_set_by_name(TestDynamicSetGetComponent::get_component_id(), component, SNAME("enable_color"), false);
+
+	// Make sure we can't fetch color:
+	Variant color;
+	CHECK(!ECS::unsafe_component_get_by_name(
+			TestDynamicSetGetComponent::get_component_id(),
+			component,
+			SNAME("color"),
+			color));
+
+	// Make sure we can't set
+	CHECK(!ECS::unsafe_component_set_by_name(
+			TestDynamicSetGetComponent::get_component_id(),
+			component,
+			SNAME("color"),
+			Color(0.0, 1.0, 0.0)));
+}
+} // namespace godex_component_test
 #endif // TEST_ECS_COMOPNENT_H


### PR DESCRIPTION
This allow to have components (and shared components) with variable
properties, which is useful to expose arrays, or structure with dynamic
properites.

To use this featues it's necessary to implement the functions:
- `bool _set(const StringName &p_name, const Variant &p_value);`
- `bool _get(const StringName &p_name, Variant &r_value) const;`
- `void _get_property_list(List<PropertyInfo> *r_list) const;`

Here an example:
```c++
/// This Component accepts a color property on if the paramter `enable_color` is true.
struct TestDynamicSetGetComponent {
	COMPONENT(TestDynamicSetGetComponent, DenseVectorStorage);

	static void _bind_methods() {
		ECS_BIND_PROPERTY(TestDynamicSetGetComponent, PropertyInfo(Variant::BOOL, "enable_color"), enable_color);
	}

	void _get_property_list(List<PropertyInfo> *r_list) {
		if (enable_color) {
			r_list->push_back(PropertyInfo(Variant::COLOR, "color"));
		}
	}

	bool _set(const StringName &p_name, const Variant &p_value) {
		if (enable_color) {
			if (p_name == SNAME("color")) {
				meta[SNAME("color")] = p_value;
				return true;
			}
		}
		return false;
	}

	bool _get(const StringName &p_name, Variant &r_value) const {
		if (enable_color) {
			if (p_name == SNAME("color")) {
				if (meta.has(SNAME("color"))) {
					r_value = meta[SNAME("color")];
				} else {
					// Default color.
					r_value = Color(1.0, 0.0, 0.0);
				}
				return true;
			}
		}
		return false;
	}

	bool enable_color = false;
	Dictionary meta;
};
```

https://user-images.githubusercontent.com/8342599/131245318-a4f055d2-93a8-4105-9d20-728c81996daf.mp4

---
Fixes: https://github.com/GodotECS/godex/issues/139
