### PR TITLE
Change PROPERTY_USAGE_NOEDITOR to PROPERTY_USAGE_NO_EDITOR

### DIFF
--- a/components/child.cpp
+++ b/components/child.cpp
@@ -1,7 +1,7 @@
 #include "child.h"
 
 void Child::_bind_methods() {
-	ECS_BIND_PROPERTY(Child, PropertyInfo(Variant::INT, "parent", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), parent);
+	ECS_BIND_PROPERTY(Child, PropertyInfo(Variant::INT, "parent", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), parent);
 }
 
 void Child::_get_storage_config(Dictionary &r_dictionary) {

--- a/modules/godot/components/transform_component.cpp
+++ b/modules/godot/components/transform_component.cpp
@@ -3,7 +3,7 @@
 #include "core/math/math_funcs.h"
 
 void TransformComponent::_bind_methods() {
-	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::TRANSFORM3D, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), set_self_script, get_self_script);
+	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::TRANSFORM3D, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), set_self_script, get_self_script);
 	ECS_BIND_PROPERTY(TransformComponent, PropertyInfo(Variant::VECTOR3, "origin", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), origin);
 	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::VECTOR3, "rotation_deg", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), set_rotation_deg, get_rotation_deg);
 	ECS_BIND_PROPERTY_FUNC(TransformComponent, PropertyInfo(Variant::VECTOR3, "scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), set_scale, get_scale);


### PR DESCRIPTION
`PROPERTY_USAGE_NOEDITOR` has been recently renamed to `PROPERTY_USAGE_NO_EDITOR` on master, for consistency with other constants.

See: https://github.com/godotengine/godot/commit/c012fbc8b235b86ed70c501834825d91292f8811