### PR TITLE
#273 Add cron job to build the executable daily

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,6 +1,11 @@
 name: 🐧 Linux Builds
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 # Global Settings
 env:

--- a/.github/workflows/update_wiki.yml
+++ b/.github/workflows/update_wiki.yml
@@ -11,15 +11,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Download makerst.py
+      - name: Download make_rst.py
         uses: carlosperate/download-file-action@v1.0.3
         with:
-          file-url: https://raw.githubusercontent.com/godotengine/godot/master/doc/tools/makerst.py
+          file-url: https://raw.githubusercontent.com/godotengine/godot/master/doc/tools/make_rst.py
 
       - name: Export XML documentation to RST and fix up for Github
         run: |
           mkdir .wiki
-          python3 ./makerst.py --output .wiki/ doc_classes/ || /bin/true
+          python3 ./make_rst.py --output .wiki/ doc_classes/ || /bin/true
           cd .wiki
           for i in *
           do

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,5 +1,11 @@
 name: 🏁 Windows Builds
-on: [push, pull_request, workflow_dispatch]
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment


### PR DESCRIPTION
As mentioned in issue https://github.com/GodotECS/godex/issues/273, in this PR I added cron tasks for building the linux and windows versions, each day.

I could see that the url of the makerst.py file that was used to build the doc was no longer valid.