### PR TITLE
fix compilation for current godot

### DIFF
--- a/modules/godot/editor_plugins/editor_world_ecs.cpp
+++ b/modules/godot/editor_plugins/editor_world_ecs.cpp
@@ -1262,7 +1262,7 @@ void EditorWorldECS::add_error(const String &p_msg) {
 	Label *lbl = memnew(Label);
 	lbl->set_text("- [Error] " + p_msg);
 	lbl->add_theme_color_override(SNAME("font_color"), Color(0.95, 0.05, 0));
-	lbl->set_autowrap_mode(Label::AutowrapMode::AUTOWRAP_WORD_SMART);
+	lbl->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	errors_warnings_container->add_child(lbl);
 }
 
@@ -1270,7 +1270,7 @@ void EditorWorldECS::add_warning(const String &p_msg) {
 	Label *lbl = memnew(Label);
 	lbl->set_text("- [Warning] " + p_msg);
 	lbl->add_theme_color_override(SNAME("font_color"), Color(0.96, 0.9, 0.45));
-	lbl->set_autowrap_mode(Label::AutowrapMode::AUTOWRAP_WORD_SMART);
+	lbl->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	errors_warnings_container->add_child(lbl);
 }
 


### PR DESCRIPTION
Hi there,

the current godex master (`1d2e23a42ed57e3017f3efb6a8fafc8912141b08`) branch does not compile with current godot master (`8d15814e6a211646a04478978224fd1af41a75cc`). This patch fixes this by adjusting two lines.

Cheers,
tpltnt