### PR TITLE
Resolving Compile/Linker Error: ODR issue with 'Dependency' class/struct

### DIFF
--- a/ecs.cpp
+++ b/ecs.cpp
@@ -806,8 +806,8 @@ int ECS::get_dispatcher_index(godex::system_id p_id) {
 	return systems_info[p_id].dispatcher_index;
 }
 
-const LocalVector<Dependency> &ECS::get_system_dependencies(godex::system_id p_id) {
-	static const LocalVector<Dependency> dep;
+const LocalVector<SystemDependency> &ECS::get_system_dependencies(godex::system_id p_id) {
+	static const LocalVector<SystemDependency> dep;
 	ERR_FAIL_COND_V_MSG(verify_system_id(p_id) == false, dep, "The SystemID: " + itos(p_id) + " doesn't exists. Are you passing a System ID?");
 	return systems_info[p_id].dependencies;
 }

--- a/ecs.h
+++ b/ecs.h
@@ -30,11 +30,6 @@ enum Phase : int {
 	PHASE_MAX,
 };
 
-struct Dependency {
-	bool execute_before;
-	StringName system_name;
-};
-
 struct DataAccessorFuncs {
 	const LocalVector<PropertyInfo> *(*get_static_properties)() = nullptr;
 	void (*get_property_list)(void *p_self, List<PropertyInfo> *r_list) = nullptr;
@@ -91,6 +86,11 @@ enum Flags {
 	EXCLUDE_PIPELINE_COMPOSITION = 1 << 1,
 };
 
+struct SystemDependency {
+	bool execute_before;
+	StringName system_name;
+};
+
 class SystemInfo {
 	friend class ECS;
 	friend class SystemBundleInfo;
@@ -105,7 +105,7 @@ class SystemInfo {
 	godex::system_id id = godex::SYSTEM_NONE;
 	Phase phase = PHASE_PROCESS;
 	StringName dispatcher;
-	LocalVector<Dependency> dependencies;
+	LocalVector<SystemDependency> dependencies;
 	String description;
 	Type type = TYPE_NORMAL;
 	int dispatcher_index = -1;
@@ -136,7 +136,7 @@ class SystemBundleInfo {
 	String description;
 	LocalVector<StringName> systems;
 	/// Bundle dependencies.
-	LocalVector<Dependency> dependencies;
+	LocalVector<SystemDependency> dependencies;
 
 public:
 	SystemBundleInfo &set_description(const String &p_description);
@@ -454,7 +454,7 @@ public:
 	static Phase get_system_phase(godex::system_id p_id);
 	static StringName get_system_dispatcher(godex::system_id p_id);
 	static int get_dispatcher_index(godex::system_id p_id);
-	static const LocalVector<Dependency> &get_system_dependencies(godex::system_id p_id);
+	static const LocalVector<SystemDependency> &get_system_dependencies(godex::system_id p_id);
 	static int get_system_flags(godex::system_id p_id);
 
 	/// Returns `true` when the system dispatches a pipeline when executed.

--- a/pipeline/pipeline_builder.cpp
+++ b/pipeline/pipeline_builder.cpp
@@ -221,7 +221,7 @@ void PipelineBuilder::build_graph(
 
 	fetch_bundle_info(p_system_bundles, r_graph);
 	for (int i = 0; i < p_systems.size(); i += 1) {
-		fetch_system_info(p_systems[i], StringName(), -1, LocalVector<Dependency>(), r_graph);
+		fetch_system_info(p_systems[i], StringName(), -1, LocalVector<SystemDependency>(), r_graph);
 	}
 
 	String error;
@@ -404,7 +404,7 @@ void PipelineBuilder::fetch_system_info(
 		const StringName &p_system,
 		const StringName &p_bundle_name,
 		int p_explicit_priority,
-		const LocalVector<Dependency> &p_extra_dependencies,
+		const LocalVector<SystemDependency> &p_extra_dependencies,
 		ExecutionGraph *r_graph) {
 	godex::system_id id = ECS::get_system_id(p_system);
 	if (id == godex::SYSTEM_NONE) {
@@ -482,7 +482,7 @@ void PipelineBuilder::fetch_system_info(
 
 void PipelineBuilder::resolve_dependencies(
 		godex::system_id id,
-		const LocalVector<Dependency> &p_dependencies,
+		const LocalVector<SystemDependency> &p_dependencies,
 		ExecutionGraph *r_graph) {
 	for (uint32_t i = 0; i < p_dependencies.size(); i += 1) {
 		const godex::system_id dep_system_id = ECS::get_system_id(p_dependencies[i].system_name);

--- a/pipeline/pipeline_builder.h
+++ b/pipeline/pipeline_builder.h
@@ -138,12 +138,12 @@ private:
 			const StringName &p_system,
 			const StringName &p_bundle_name,
 			int p_explicit_priority,
-			const LocalVector<Dependency> &p_extra_dependencies,
+			const LocalVector<SystemDependency> &p_extra_dependencies,
 			ExecutionGraph *r_graph);
 
 	static void resolve_dependencies(
 			godex::system_id id,
-			const LocalVector<Dependency> &p_dependencies,
+			const LocalVector<SystemDependency> &p_dependencies,
 			ExecutionGraph *r_graph);
 
 	static bool sort_systems(ExecutionGraph *r_graph, String &r_error_msg);


### PR DESCRIPTION
Hello There.

As it seems, the current build will not compile for me - Windows MSVC with debug and release_debug configurations. 
Godex Commit: 1d2e23a42ed57e3017f3efb6a8fafc8912141b08 
Godot Commit: https://github.com/godotengine/godot/commit/667cef39b4e9f98ed545d95de442319c447f2164

- The first issue is the Autowrap-Label, but that has already been addressed in https://github.com/GodotECS/godex/pull/297. 
- The other issue is a linker error when trying to compile the godot executable. See following...

```cpp
[ 73%] Linking Static Library servers\servers.windows.opt.tools.64.lib ...
... godot.vsproj configuration setup...
[ 96%] progress_finish(["progress_finish"], [])
[100%] Linking Static Library modules\module_gdscript.windows.opt.tools.64.lib ...
[100%] Linking Static Library core\core.windows.opt.tools.64.lib ...
[100%] Linking Program bin\godot.windows.opt.tools.64.exe ...

servers.windows.opt.tools.64.lib(utilities.windows.opt.tools.64.obj) : error LNK2005: "public: __cdecl Dependency::~Dependency(void)" (??1Dependency@@QEAA@XZ) already defined in module_godex.windows.opt.tools.64.lib(ecs.windows.opt.tools.64.obj)
   Creating library bin\godot.windows.opt.tools.64.lib and object bin\godot.windows.opt.tools.64.exp
bin\godot.windows.opt.tools.64.exe : fatal error LNK1169: one or more multiply defined symbols found

scons: *** [bin\godot.windows.opt.tools.64.exe] Error 1169
scons: building terminated because of errors.
[Time elapsed: 00:34:11.568]
```

My commit(https://github.com/TDCRanila/godex/commit/a1df1c6b07bbc1540271d024b9698857aee01655) simply renames the 'Dependency' class to 'SystemDependency' to resolve the issue. :) (Putting 'Dependency' in the 'godex' namespace would also work fine and avoid future conflicts if that is preferable.)