### PR TITLE
Resolving build errors on latest Godot[11abffb]/Godex build

### DIFF
--- a/modules/godot/editor_plugins/editor_world_ecs.cpp
+++ b/modules/godot/editor_plugins/editor_world_ecs.cpp
@@ -10,6 +10,7 @@
 #include "editor/editor_scale.h"
 #include "scene/gui/color_rect.h"
 #include "scene/gui/reference_rect.h"
+#include "scene/gui/separator.h"
 
 PipelineElementInfoBox::PipelineElementInfoBox(EditorNode *p_editor, EditorWorldECS *p_editor_world_ecs) :
 		editor(p_editor),

--- a/modules/godot/editor_plugins/editor_world_ecs.cpp
+++ b/modules/godot/editor_plugins/editor_world_ecs.cpp
@@ -42,7 +42,7 @@ PipelineElementInfoBox::PipelineElementInfoBox(EditorNode *p_editor, EditorWorld
 	remove_btn->set_h_size_flags(0);
 	remove_btn->set_v_size_flags(0);
 	remove_btn->set_flat(true);
-	remove_btn->connect(SNAME("pressed"), callable_mp(this, &PipelineElementInfoBox::system_remove), Vector<Variant>(), CONNECT_DEFERRED);
+	remove_btn->connect(SNAME("pressed"), callable_mp(this, &PipelineElementInfoBox::system_remove), CONNECT_DEFERRED);
 	box->add_child(remove_btn);
 
 	system_name_lbl = memnew(Label);

--- a/modules/godot/editor_plugins/entity_editor_plugin.cpp
+++ b/modules/godot/editor_plugins/entity_editor_plugin.cpp
@@ -83,7 +83,7 @@ void EntityEditor::update_editors() {
 			del_btn->set_icon(editor->get_theme_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 			del_btn->set_flat(false);
 			del_btn->set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
-			del_btn->connect(SNAME("pressed"), callable_mp(this, &EntityEditor::_remove_component_pressed), varray(*it.key));
+			del_btn->connect(SNAME("pressed"), callable_mp(this, &EntityEditor::_remove_component_pressed).bind(*it.key));
 			component_section->get_vbox()->add_child(del_btn);
 
 			create_component_inspector(*it.key, *it.value, component_section->get_vbox());

--- a/modules/godot/nodes/ecs_world.cpp
+++ b/modules/godot/nodes/ecs_world.cpp
@@ -331,7 +331,7 @@ void WorldECS::_notification(int p_what) {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				init_default();
 
-				ScriptEcs::get_singleton()->connect("ecs_script_reloaded", callable_mp(this, &WorldECS::on_ecs_script_reloaded), Vector<Variant>(), CONNECT_DEFERRED);
+				ScriptEcs::get_singleton()->connect("ecs_script_reloaded", callable_mp(this, &WorldECS::on_ecs_script_reloaded), CONNECT_DEFERRED);
 			}
 #endif
 
@@ -467,12 +467,9 @@ void WorldECS::add_pipeline(Ref<PipelineECS> p_pipeline) {
 	if (Engine::get_singleton()->is_editor_hint()) {
 		update_configuration_warnings();
 
-		Vector<Variant> vars;
-		vars.push_back(p_pipeline);
 		p_pipeline->connect(
 				CoreStringNames::get_singleton()->property_list_changed,
-				callable_mp(this, &WorldECS::on_pipeline_changed),
-				vars);
+				callable_mp(this, &WorldECS::on_pipeline_changed).bind(p_pipeline));
 	}
 #endif
 }

--- a/systems/dynamic_system.cpp
+++ b/systems/dynamic_system.cpp
@@ -2,7 +2,7 @@
 
 #include "../pipeline/pipeline.h"
 #include "../utils/fetchers.h"
-#include "modules/gdscript/gdscript.cpp"
+#include "modules/gdscript/gdscript.h"
 
 godex::DynamicSystemExecutionData::DynamicSystemExecutionData() {}
 


### PR DESCRIPTION
Hi,

Several changes have been made to Godot main branch and has resulted in some build errors.

Windows MSVC with debug & release_debug configuration using:
Godex Commit: https://github.com/GodotECS/godex/commit/2186bd38900ffba677e51d9ec84944ee64e4a1cc
Godot Commit: https://github.com/godotengine/godot/commit/11abffbf1282d457f966741f14aa5a5793f3c208

Issues are;
1) Several objects where using a deprecated parameter with 'Object::Connect'. This has to do with this Godot commit: https://github.com/godotengine/godot/commit/d4433ae6d3a525683ef37ea521d30b6b97a44024 The objects that do want a binding should be using 'Callable::Bind' instead. 
(Note: Functionality should not have changed, but it might be worth to test it.)
2) In ''editor_world_ecs.cpp", VSeparator and HSeparator weren't defined, which is likely due to some changes in the Godot includes. (I did not investigate this further.)
3) There were linker errors due to inclusion of a translation unit resulting in multiple defined symbols in the linking process. I am unsure if this intended in commit: https://github.com/GodotECS/godex/commit/cf8d204be8d0fbd573b13ae3d348d029af7e803b#diff-c6cc11c18a29769a7d7c241946c0fc4715cb315a87627200b04e47dbfbd7da00 

See the pull-request for the fixes.
