### PR TITLE
Fixing GodotCPP Compile due to Godex issues

### DIFF
--- a/iterators/dynamic_query.cpp
+++ b/iterators/dynamic_query.cpp
@@ -27,6 +27,9 @@ void DynamicQuery::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_current_entity_id"), &DynamicQuery::script_get_current_entity_id);
 	ClassDB::bind_method(D_METHOD("count"), &DynamicQuery::count);
+
+	BIND_ENUM_CONSTANT(LOCAL);
+	BIND_ENUM_CONSTANT(GLOBAL);
 }
 
 DynamicQuery::DynamicQuery() {

--- a/iterators/dynamic_query.cpp
+++ b/iterators/dynamic_query.cpp
@@ -7,9 +7,9 @@ using godex::DynamicQuery;
 
 void DynamicQuery::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_space", "space"), &DynamicQuery::set_space);
-	ClassDB::bind_method(D_METHOD("with_component", "component_id", "mutable"), &DynamicQuery::with_component);
-	ClassDB::bind_method(D_METHOD("maybe_component", "component_id", "mutable"), &DynamicQuery::maybe_component);
-	ClassDB::bind_method(D_METHOD("changed_component", "component_id", "mutable"), &DynamicQuery::changed_component);
+	ClassDB::bind_method(D_METHOD("with_component", "component_id", "is_mutable"), &DynamicQuery::with_component);
+	ClassDB::bind_method(D_METHOD("maybe_component", "component_id", "is_mutable"), &DynamicQuery::maybe_component);
+	ClassDB::bind_method(D_METHOD("changed_component", "component_id", "is_mutable"), &DynamicQuery::changed_component);
 	ClassDB::bind_method(D_METHOD("not_component", "component_id"), &DynamicQuery::not_component);
 
 	ClassDB::bind_method(D_METHOD("is_valid"), &DynamicQuery::is_valid);
@@ -39,23 +39,23 @@ void DynamicQuery::set_space(Space p_space) {
 	space = p_space;
 }
 
-void DynamicQuery::with_component(uint32_t p_component_id, bool p_mutable) {
-	_with_component(p_component_id, p_mutable, WITH_MODE);
+void DynamicQuery::with_component(uint32_t p_component_id, bool p_is_mutable) {
+	_with_component(p_component_id, p_is_mutable, WITH_MODE);
 }
 
 void DynamicQuery::maybe_component(uint32_t p_component_id, bool p_mutable) {
 	_with_component(p_component_id, p_mutable, MAYBE_MODE);
 }
 
-void DynamicQuery::changed_component(uint32_t p_component_id, bool p_mutable) {
-	_with_component(p_component_id, p_mutable, CHANGED_MODE);
+void DynamicQuery::changed_component(uint32_t p_component_id, bool p_is_mutable) {
+	_with_component(p_component_id, p_is_mutable, CHANGED_MODE);
 }
 
 void DynamicQuery::not_component(uint32_t p_component_id) {
 	_with_component(p_component_id, false, WITHOUT_MODE);
 }
 
-void DynamicQuery::_with_component(uint32_t p_component_id, bool p_mutable, FetchMode p_mode) {
+void DynamicQuery::_with_component(uint32_t p_component_id, bool p_is_mutable, FetchMode p_mode) {
 	ERR_FAIL_COND_MSG(is_valid() == false, "This query is not valid.");
 	ERR_FAIL_COND_MSG(can_change == false, "This query can't change at this point, you have to `clear` it.");
 	if (unlikely(ECS::verify_component_id(p_component_id) == false)) {
@@ -69,7 +69,7 @@ void DynamicQuery::_with_component(uint32_t p_component_id, bool p_mutable, Fetc
 	DynamicQueryElement data;
 	data.id = p_component_id;
 	data.name = ECS::get_component_name(p_component_id);
-	data.mutability = p_mutable;
+	data.mutability = p_is_mutable;
 	data.mode = p_mode;
 	data.entity_list_index = UINT32_MAX;
 	elements.push_back(data);

--- a/iterators/dynamic_query.cpp
+++ b/iterators/dynamic_query.cpp
@@ -7,9 +7,9 @@ using godex::DynamicQuery;
 
 void DynamicQuery::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_space", "space"), &DynamicQuery::set_space);
-	ClassDB::bind_method(D_METHOD("with_component", "component_id", "is_mutable"), &DynamicQuery::with_component);
-	ClassDB::bind_method(D_METHOD("maybe_component", "component_id", "is_mutable"), &DynamicQuery::maybe_component);
-	ClassDB::bind_method(D_METHOD("changed_component", "component_id", "is_mutable"), &DynamicQuery::changed_component);
+	ClassDB::bind_method(D_METHOD("with_component", "component_id", "is_mutable"), &DynamicQuery::with_component, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("maybe_component", "component_id", "is_mutable"), &DynamicQuery::maybe_component, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("changed_component", "component_id", "is_mutable"), &DynamicQuery::changed_component, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("not_component", "component_id"), &DynamicQuery::not_component);
 
 	ClassDB::bind_method(D_METHOD("is_valid"), &DynamicQuery::is_valid);

--- a/iterators/dynamic_query.h
+++ b/iterators/dynamic_query.h
@@ -57,14 +57,14 @@ public:
 	void set_space(Space p_space);
 
 	/// Add component.
-	void with_component(uint32_t p_component_id, bool p_mutable = false);
-	void maybe_component(uint32_t p_component_id, bool p_mutable = false);
-	void changed_component(uint32_t p_component_id, bool p_mutable = false);
+	void with_component(uint32_t p_component_id, bool p_is_mutable = false);
+	void maybe_component(uint32_t p_component_id, bool p_is_mutable = false);
+	void changed_component(uint32_t p_component_id, bool p_is_mutable = false);
 
 	/// Excludes this component from the query.
 	void not_component(uint32_t p_component_id);
 
-	void _with_component(uint32_t p_component_id, bool p_mutable, FetchMode p_mode);
+	void _with_component(uint32_t p_component_id, bool p_is_mutable, FetchMode p_mode);
 
 	/// Returns true if this query is valid.
 	bool is_valid() const;

--- a/modules/godot/editor_plugins/editor_world_ecs.cpp
+++ b/modules/godot/editor_plugins/editor_world_ecs.cpp
@@ -10,6 +10,7 @@
 #include "editor/editor_scale.h"
 #include "scene/gui/color_rect.h"
 #include "scene/gui/reference_rect.h"
+#include "scene/gui/separator.h"
 
 PipelineElementInfoBox::PipelineElementInfoBox(EditorNode *p_editor, EditorWorldECS *p_editor_world_ecs) :
 		editor(p_editor),

--- a/modules/godot/editor_plugins/editor_world_ecs.cpp
+++ b/modules/godot/editor_plugins/editor_world_ecs.cpp
@@ -42,7 +42,7 @@ PipelineElementInfoBox::PipelineElementInfoBox(EditorNode *p_editor, EditorWorld
 	remove_btn->set_h_size_flags(0);
 	remove_btn->set_v_size_flags(0);
 	remove_btn->set_flat(true);
-	remove_btn->connect(SNAME("pressed"), callable_mp(this, &PipelineElementInfoBox::system_remove), Vector<Variant>(), CONNECT_DEFERRED);
+	remove_btn->connect(SNAME("pressed"), callable_mp(this, &PipelineElementInfoBox::system_remove), CONNECT_DEFERRED);
 	box->add_child(remove_btn);
 
 	system_name_lbl = memnew(Label);

--- a/modules/godot/editor_plugins/entity_editor_plugin.cpp
+++ b/modules/godot/editor_plugins/entity_editor_plugin.cpp
@@ -83,7 +83,7 @@ void EntityEditor::update_editors() {
 			del_btn->set_icon(editor->get_theme_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 			del_btn->set_flat(false);
 			del_btn->set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
-			del_btn->connect(SNAME("pressed"), callable_mp(this, &EntityEditor::_remove_component_pressed), varray(*it.key));
+			del_btn->connect(SNAME("pressed"), callable_mp(this, &EntityEditor::_remove_component_pressed).bind(*it.key));
 			component_section->get_vbox()->add_child(del_btn);
 
 			create_component_inspector(*it.key, *it.value, component_section->get_vbox());

--- a/modules/godot/nodes/ecs_utilities.cpp
+++ b/modules/godot/nodes/ecs_utilities.cpp
@@ -27,6 +27,13 @@ void System::_bind_methods() {
 	BIND_ENUM_CONSTANT(IMMUTABLE);
 	BIND_ENUM_CONSTANT(MUTABLE);
 
+	BIND_ENUM_CONSTANT(PHASE_CONFIG);
+	BIND_ENUM_CONSTANT(PHASE_INPUT);
+	BIND_ENUM_CONSTANT(PHASE_PRE_PROCESS);
+	BIND_ENUM_CONSTANT(PHASE_PROCESS);
+	BIND_ENUM_CONSTANT(PHASE_POST_PROCESS);
+	BIND_ENUM_CONSTANT(PHASE_PRE_RENDER);
+
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_prepare"));
 	// TODO how to define `_execute`? It has  dynamic argument, depending on the `_prepare` function.
 }

--- a/modules/godot/nodes/ecs_world.cpp
+++ b/modules/godot/nodes/ecs_world.cpp
@@ -331,7 +331,7 @@ void WorldECS::_notification(int p_what) {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				init_default();
 
-				ScriptEcs::get_singleton()->connect("ecs_script_reloaded", callable_mp(this, &WorldECS::on_ecs_script_reloaded), Vector<Variant>(), CONNECT_DEFERRED);
+				ScriptEcs::get_singleton()->connect("ecs_script_reloaded", callable_mp(this, &WorldECS::on_ecs_script_reloaded), CONNECT_DEFERRED);
 			}
 #endif
 
@@ -467,12 +467,9 @@ void WorldECS::add_pipeline(Ref<PipelineECS> p_pipeline) {
 	if (Engine::get_singleton()->is_editor_hint()) {
 		update_configuration_warnings();
 
-		Vector<Variant> vars;
-		vars.push_back(p_pipeline);
 		p_pipeline->connect(
 				CoreStringNames::get_singleton()->property_list_changed,
-				callable_mp(this, &WorldECS::on_pipeline_changed),
-				vars);
+				callable_mp(this, &WorldECS::on_pipeline_changed).bind(p_pipeline));
 	}
 #endif
 }

--- a/modules/godot/nodes/entity.cpp
+++ b/modules/godot/nodes/entity.cpp
@@ -45,6 +45,9 @@ void Entity3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_reference_by_nodepath", "active"), &Entity3D::set_reference_by_nodepath);
 	ClassDB::bind_method(D_METHOD("get_reference_by_nodepath"), &Entity3D::get_reference_by_nodepath);
 
+	BIND_ENUM_CONSTANT(LOCAL);
+	BIND_ENUM_CONSTANT(GLOBAL);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync_transform"), "set_sync_transform", "get_sync_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reference_by_nodepath"), "set_reference_by_nodepath", "get_reference_by_nodepath");
 }
@@ -66,6 +69,9 @@ void Entity2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_reference_by_nodepath", "active"), &Entity2D::set_reference_by_nodepath);
 	ClassDB::bind_method(D_METHOD("get_reference_by_nodepath"), &Entity2D::get_reference_by_nodepath);
+
+	BIND_ENUM_CONSTANT(LOCAL);
+	BIND_ENUM_CONSTANT(GLOBAL);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync_transform"), "set_sync_transform", "get_sync_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reference_by_nodepath"), "set_reference_by_nodepath", "get_reference_by_nodepath");

--- a/systems/dynamic_system.cpp
+++ b/systems/dynamic_system.cpp
@@ -2,7 +2,7 @@
 
 #include "../pipeline/pipeline.h"
 #include "../utils/fetchers.h"
-#include "modules/gdscript/gdscript.cpp"
+#include "modules/gdscript/gdscript.h"
 
 godex::DynamicSystemExecutionData::DynamicSystemExecutionData() {}
 


### PR DESCRIPTION
Hello again,

I am looking to create a game with support of a Godot GDExtension/Addon in combination with Godex. And in order to do that with a modified engine (the addition of Godex in this case), you need to update the GodotCPP Headers. [Update GodotCPP Header](https://github.com/godotengine/godot-cpp/blob/master/godot-headers/README.md)

I followed the instructions and updating the headers went fine. However, when compiling GodotCPP there were some Godex issues making it fail. I have attached some fixes for that in the PR. 
(Windows MSVC with debug configuration using; Godot Commit: godotengine/godot@11abffb)

There are some things were I am a little unsure of, so let me know what you think. :)
1) In the Godot source, I haven't seen 'BIND_ENUM_CONSTANT' used multiple times for the same enum but for different classes, however, looking at the generated output and the define, I don't think that could be a problem.
2) Last thing, I noticed that the 'PHASE_FINALIZE_PROCESS' flag for the 'Phase' enum is being excluded from binding in the ecs.cpp@_binds_methods. Is that on purpose or perhaps forgotten?