### PR TITLE
Fix: GitHub Workflows [Windows]

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,9 +1,7 @@
 name: 🐧 Linux Builds
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 # Global Settings

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,102 +1,100 @@
 name: 🐧 Linux Builds
-
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'
 
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=linuxbsd verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
+  SCONSFLAGS: platform=linuxbsd arch=x86_64 verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
   linux-editor:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     name: Editor (target=release_debug, tools=yes, tests=yes)
 
     steps:
-    - name: Make godot dir
-      run: |
-       mkdir godot
-       mkdir modules
-       mkdir modules/godex
+      - name: Make godot dir
+        run: |
+          mkdir godot
+          mkdir modules
+          mkdir modules/godex
 
-    - name: Clone godex
-      uses: actions/checkout@v2
-      with:
-       path: modules/godex
+      - name: Clone godex
+        uses: actions/checkout@v2
+        with:
+          path: modules/godex
 
-    - name: Clone godot for godex
-      uses: actions/checkout@v2
-      with:
-       repository: GodotECS/godot
-       ref: refs/heads/godex_version
-       path: godot
+      - name: Clone godot for godex
+        uses: actions/checkout@v2
+        with:
+          repository: GodotECS/godot
+          ref: refs/heads/godex_version
+          path: godot
 
-    # Azure repositories are not reliable, we need to prevent azure giving us packages.
-    - name: Make apt sources.list use the default Ubuntu repositories
-      run: |
-       sudo rm -f /etc/apt/sources.list.d/*
-       sudo cp -f modules/godex/misc/ci/sources.list /etc/apt/sources.list
-       sudo apt-get update
+      # Azure repositories are not reliable, we need to prevent azure giving us packages.
+      - name: Make apt sources.list use the default Ubuntu repositories
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f modules/godex/misc/ci/sources.list /etc/apt/sources.list
+          sudo apt-get update
 
-    # Install all packages (except scons)
-    - name: Configure dependencies
-      run: |
+      # Install all packages (except scons)
+      - name: Configure dependencies
+        run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
             libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
 
-    # Upload cache on completion and check it out now
-    - name: Load .scons_cache directory
-      id: linux-editor-cache
-      uses: actions/cache@v2
-      with:
-       path: ${{github.workspace}}/.scons_cache/
-       key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-       restore-keys: |
-        ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-        ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
-        ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
+      # Upload cache on completion and check it out now
+      - name: Load .scons_cache directory
+        id: linux-editor-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
-    # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v2
-      with:
-       # Semantic version range syntax or exact version of a Python version
-       python-version: '3.x'
-       # Optional - x64 or x86 architecture, defaults to x64
-       architecture: 'x64'
+      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: "3.x"
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: "x64"
 
-    # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
-    - name: Configuring Python packages
-      run: |
-       python -c "import sys; print(sys.version)"
-       python -m pip install scons
-       python --version
-       scons --version
+      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
+      - name: Configuring Python packages
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons
+          python --version
+          scons --version
 
-    - name: Compilation
-      env:
-        SCONS_CACHE: ${{github.workspace}}/.scons_cache/
-      run: |
-       cd godot
-       scons tools=yes tests=yes target=release_debug custom_modules="../modules" -j2
-       ls -l bin/
+      - name: Compilation
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+        run: |
+          cd godot
+          scons tools=yes tests=yes target=release_debug custom_modules="../modules" -j2
+          ls -l bin/
 
-    # Execute unit tests for the editor
-    - name: Unit Tests
-      run: |
-        cd ./godot
-        ./bin/godot.linuxbsd.opt.tools.64 --test
-        cd ../
+      # Execute unit tests for the editor
+      - name: Unit Tests
+        run: |
+          cd ./godot
+          ./bin/godot.linuxbsd.opt.tools.64 --test
+          cd ../
 
-    - uses: actions/upload-artifact@v2
-      with:
-       name: ${{ github.job }}
-       path: godot/bin/*
-       retention-days: 14
-
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: godot/bin/*
+          retention-days: 14

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,5 +1,8 @@
 name: 📊 Static Checks
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   static-checks:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -33,4 +33,3 @@ jobs:
       #- name: Documentation checks
       #  run: |
       #    doc/tools/makerst.py --dry-run doc/classes modules
-

--- a/.github/workflows/update_wiki.yml
+++ b/.github/workflows/update_wiki.yml
@@ -1,8 +1,8 @@
 name: Update DOC wiki
 on:
   push:
-    branches: main
-    paths: doc_classes/*
+    branches: [main]
+    paths: [doc_classes/*]
 
 jobs:
   wiki:
@@ -35,4 +35,3 @@ jobs:
           user: GodexBot
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,9 +1,7 @@
 name: 🏁 Windows Builds
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 # Global Settings

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,94 +1,92 @@
 name: 🏁 Windows Builds
-
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'
 
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=windows verbose=yes warnings=all werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
+  SCONSFLAGS: platform=windows arch=x86_64 verbose=yes warnings=all werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_MSVC_CONFIG: true
   SCONS_CACHE_LIMIT: 3072
 
 jobs:
   windows-editor:
     # Windows 10 with latest image
-    runs-on: "windows-latest"
+    runs-on: windows-latest
     name: Editor (target=release_debug, tools=yes, tests=yes)
 
     steps:
-    - name: Make dir
-      run: |
-       mkdir godot
-       mkdir modules
-       mkdir modules/godex
+      - name: Make dir
+        run: |
+          mkdir godot
+          mkdir modules
+          mkdir modules/godex
 
-    - name: Clone godex
-      uses: actions/checkout@v2
-      with:
-       path: modules/godex
+      - name: Clone godex
+        uses: actions/checkout@v4
+        with:
+          path: modules/godex
 
-    - name: Clone godot for godex
-      uses: actions/checkout@v2
-      with:
-       repository: GodotECS/godot
-       ref: refs/heads/godex_version
-       path: godot
+      - name: Clone godot for godex
+        uses: actions/checkout@v4
+        with:
+          repository: GodotECS/godot
+          ref: refs/heads/godex_version
+          path: godot
 
-    # Upload cache on completion and check it out now
-    # Editing this is pretty dangerous for Windows since it can break and needs to be properly tested with a fresh cache.
-    - name: Load .scons_cache directory
-      id: windows-editor-cache
-      uses: actions/cache@v2
-      with:
-        path: ${{github.workspace}}/.scons_cache/
-        key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-        restore-keys: |
-          ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-          ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
-          ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
+      # Upload cache on completion and check it out now
+      # Editing this is pretty dangerous for Windows since it can break and needs to be properly tested with a fresh cache.
+      - name: Load .scons_cache directory
+        id: windows-editor-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{github.workspace}}/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
-    # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v2
-      with:
-        # Semantic version range syntax or exact version of a Python version
-        python-version: '3.x'
-        # Optional - x64 or x86 architecture, defaults to x64
-        architecture: 'x64'
+      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: "3.x"
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: "x64"
 
-    # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
-    - name: Configuring Python packages
-      run: |
-        python -c "import sys; print(sys.version)"
-        python -m pip install scons pywin32
-        python --version
-        scons --version
+      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
+      - name: Configuring Python packages
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons pywin32
+          python --version
+          scons --version
 
-    # We should always be explicit with our flags usage here since it's gonna be sure to always set those flags
-    - name: Compilation
-      env:
-        SCONS_CACHE: ${{github.workspace}}/.scons_cache/
-      run: |
-        cd godot
-        scons tools=yes tests=yes target=release_debug custom_modules="../modules"
-        ls -l bin/
+      # We should always be explicit with our flags usage here since it's gonna be sure to always set those flags
+      - name: Compilation
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+        run: |
+          cd godot
+          scons tools=yes tests=yes target=release_debug custom_modules="../modules"
+          ls -l bin/
 
-    # Execute unit tests for the editor
-    - name: Unit Tests
-      run: |
-        cd ./godot
-        ./bin/godot.windows.opt.tools.64.exe --test
-        cd ../
+      # Execute unit tests for the editor
+      - name: Unit Tests
+        run: |
+          cd ./godot
+          ./bin/godot.windows.opt.tools.64.exe --test
+          cd ../
 
-    - uses: actions/upload-artifact@v2
-      with:
-       name: ${{ github.job }}
-       path: godot/bin/*
-       retention-days: 14
-
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}
+          path: godot/bin/*
+          retention-days: 14


### PR DESCRIPTION
Remove the scheduled cron jobs from GitHub workflows so that they don't keep running forever for nothing
Also fixed the GitHub workflow for Windows builds
Tried the same for Linux builds and tried to config macOS builds but too much unexpected behaviors and as the `Compile` page in the wiki is blocked I've tried to fix it anyway and failed